### PR TITLE
Use torrent_content.info_hash instead of torrent_content.id in Torznab result

### DIFF
--- a/internal/torznab/adapter/search.go
+++ b/internal/torznab/adapter/search.go
@@ -249,7 +249,7 @@ func (a adapter) transformSearchResult(req torznab.SearchRequest, res search.Tor
 			Title:    item.Torrent.Name,
 			Size:     item.Torrent.Size,
 			Category: category,
-			GUID:     item.ID,
+			GUID:     item.InfoHash.String(),
 			PubDate:  torznab.RssDate(date),
 			Enclosure: torznab.SearchResultItemEnclosure{
 				URL:    item.Torrent.Magnet(),


### PR DESCRIPTION
See https://github.com/bitmagnet-io/bitmagnet/issues/29