### PR TITLE
Reject specific content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/bitmagnet-io/bitmagnet
 
 go 1.21
 
+replace github.com/bitmagnet-io/bitmagnet/internal/reject => ./internal/reject
+
 require (
 	github.com/99designs/gqlgen v0.17.38
 	github.com/abice/go-enum v0.5.8

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pemistahl/lingua-go v1.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -335,6 +335,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+github.com/pemistahl/lingua-go v1.4.0 h1:ifYhthrlW7iO4icdubwlduYnmwU37V1sbNrwhKBR4rM=
+github.com/pemistahl/lingua-go v1.4.0/go.mod h1:ECuM1Hp/3hvyh7k8aWSqNCPlTxLemFZsRjocUf3KgME=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/dht/staging/staging.go
+++ b/internal/dht/staging/staging.go
@@ -299,9 +299,14 @@ func (s *staging) Respond(ctx context.Context, res Response) {
 	defer delete(s.activeRequests, res.InfoHash)
 	if req.NeedMetaInfo && res.MetaInfo.PieceLength > 0 {
 
-		if reject.ContainsBanWord(res.MetaInfo.BestName()) {
+		bestName := res.MetaInfo.BestName()
+		if reject.ContainsBanWord(bestName) {
 			s.logger.Infof("Found ban word")
 			return
+		}
+
+		if reject.IsLanguageNotAllowed(bestName) {
+			s.logger.Infof("Reject language not wanted : %s", bestName)
 		}
 
 		t, tErr := createTorrentModel(res.InfoHash, res.MetaInfo, res.Scrape)

--- a/internal/reject/language.go
+++ b/internal/reject/language.go
@@ -1,0 +1,22 @@
+package reject
+
+import (
+	"github.com/pemistahl/lingua-go"
+)
+
+func IsLanguageNotAllowed(title string) bool {
+	languages := []lingua.Language{
+		lingua.English,
+		lingua.French,
+		lingua.German,
+		lingua.Spanish,
+		lingua.Italian,
+	}
+
+	detector := lingua.NewLanguageDetectorBuilder().
+		FromLanguages(languages...).
+		Build()
+
+	_, exists := detector.DetectLanguageOf(title)
+	return !exists
+}

--- a/internal/reject/wordlist.go
+++ b/internal/reject/wordlist.go
@@ -1,0 +1,29 @@
+package reject
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ContainsBanWord(title string) bool {
+	file, err := os.Open("word_blacklist")
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if strings.Contains(strings.ToLower(title), strings.ToLower(scanner.Text())) {
+			return true
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Println(err)
+	}
+
+	return false
+}

--- a/word_blacklist
+++ b/word_blacklist
@@ -1,0 +1,32 @@
+1yo
+2yo
+3yo
+4yo
+5yo
+6yo
+7yo
+8yo
+9yo
+10yo
+11yo
+12yo
+13yo
+14yo
+15yo
+16yo
+17yo
+PEDO
+CHILD PORN
+CHILDPORN
+PRETEEN
+PEDODAD
+PORNCHILD
+PORN CHILD
+ZOOPHIL
+PORN ANIMAL
+INCEST
+BRUTAL PORN
+pthc
+ptsc
+pcsn
+rape


### PR DESCRIPTION
Hi first of all, you have done a wonderfull work.
I'll definitively use it as my first choise.

In your roadmap you mention smart deletion including CSAM.
For me it is a priority, to exclude those torrents.

I started a package called reject in which we can exclude torrents with a wordlist and also by language. It use https://github.com/pemistahl/lingua-go to detect language.

For now I agree this is a draft and I need to config the package and I wanted your opinion on how you would imagine that.

The wordlist is what I already notice when I crawled the dht some time ago.
