### PR TITLE
Add checkers to reject crawled torrents based on criteria

### DIFF
--- a/internal/dhtcrawler/crawler.go
+++ b/internal/dhtcrawler/crawler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/dht/ktable"
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/dht/server"
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo/banning"
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo/metainforequester"
 	"github.com/bitmagnet-io/bitmagnet/internal/queue/publisher"
 	"go.uber.org/fx"
@@ -27,6 +28,7 @@ type Params struct {
 	KTable              ktable.Table
 	Server              server.Server
 	MetainfoRequester   metainforequester.Requester
+	BanningChecker      banning.Checker `name:"metainfo_banning_checker"`
 	Search              search.Search
 	Dao                 *dao.Query
 	ClassifierPublisher publisher.Publisher[message.ClassifyTorrentPayload]
@@ -45,6 +47,7 @@ func New(params Params) Result {
 		kTable:                       params.KTable,
 		server:                       params.Server,
 		metainfoRequester:            params.MetainfoRequester,
+		banningChecker:               params.BanningChecker,
 		bootstrapNodes:               params.Config.BootstrapNodes,
 		reseedBootstrapNodesInterval: time.Minute * 10,
 		getOldestNodesInterval:       time.Second * 10,
@@ -101,6 +104,7 @@ type crawler struct {
 	kTable                       ktable.Table
 	server                       server.Server
 	metainfoRequester            metainforequester.Requester
+	banningChecker               banning.Checker
 	bootstrapNodes               []string
 	reseedBootstrapNodesInterval time.Duration
 	getOldestNodesInterval       time.Duration

--- a/internal/dhtcrawler/request_meta_info.go
+++ b/internal/dhtcrawler/request_meta_info.go
@@ -43,6 +43,10 @@ func (c *crawler) doRequestMetaInfo(
 			addErr(err)
 			continue
 		}
+		if banErr := c.banningChecker.Check(res.Info); banErr != nil {
+			c.logger.Debugf("banning torrent '%s': %s", res.Info.BestName(), banErr)
+			return metainforequester.Response{}, banErr
+		}
 		return res, nil
 	}
 	return metainforequester.Response{}, errors.Join(errs...)

--- a/internal/protocol/metainfo/banning/checker.go
+++ b/internal/protocol/metainfo/banning/checker.go
@@ -1,0 +1,49 @@
+package banning
+
+import (
+	"errors"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
+	"go.uber.org/fx"
+)
+
+type Params struct {
+	fx.In
+	Checkers []Checker `group:"metainfo_banning_checkers"`
+}
+
+type Result struct {
+	fx.Out
+	Checker Checker `name:"metainfo_banning_checker"`
+}
+
+func New(p Params) Result {
+	checkers := p.Checkers
+	checkers = append(
+		checkers,
+		csamChecker{},
+		nameLengthChecker{min: 8},
+		sizeChecker{min: 1024},
+		utf8Checker{},
+	)
+	return Result{
+		Checker: combinedChecker{
+			checkers: checkers,
+		},
+	}
+}
+
+type Checker interface {
+	Check(metainfo.Info) error
+}
+
+type combinedChecker struct {
+	checkers []Checker
+}
+
+func (c combinedChecker) Check(info metainfo.Info) error {
+	var errs []error
+	for _, checker := range c.checkers {
+		errs = append(errs, checker.Check(info))
+	}
+	return errors.Join(errs...)
+}

--- a/internal/protocol/metainfo/banning/csam.go
+++ b/internal/protocol/metainfo/banning/csam.go
@@ -1,0 +1,32 @@
+package banning
+
+import (
+	"errors"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
+	"github.com/bitmagnet-io/bitmagnet/internal/regex"
+)
+
+var csamWords = []string{
+	"pedo",
+	"pedofile",
+	"pedofilia",
+	"preteen",
+	"pthc",
+	"ptsc",
+	"lsbar",
+	"lsm",
+	"underage",
+	"hebefilia",
+	"opva",
+}
+
+var csamRegex = regex.NewRegexFromNames(csamWords...)
+
+type csamChecker struct{}
+
+func (c csamChecker) Check(info metainfo.Info) error {
+	if csamRegex.MatchString(info.BestName()) {
+		return errors.New("torrent appears to contain CSAM")
+	}
+	return nil
+}

--- a/internal/protocol/metainfo/banning/name_length.go
+++ b/internal/protocol/metainfo/banning/name_length.go
@@ -1,0 +1,17 @@
+package banning
+
+import (
+	"errors"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
+)
+
+type nameLengthChecker struct {
+	min int
+}
+
+func (c nameLengthChecker) Check(info metainfo.Info) error {
+	if len(info.BestName()) < c.min {
+		return errors.New("name too short")
+	}
+	return nil
+}

--- a/internal/protocol/metainfo/banning/size.go
+++ b/internal/protocol/metainfo/banning/size.go
@@ -1,0 +1,17 @@
+package banning
+
+import (
+	"errors"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
+)
+
+type sizeChecker struct {
+	min int64
+}
+
+func (c sizeChecker) Check(info metainfo.Info) error {
+	if info.TotalLength() < c.min {
+		return errors.New("size too small")
+	}
+	return nil
+}

--- a/internal/protocol/metainfo/banning/utf8.go
+++ b/internal/protocol/metainfo/banning/utf8.go
@@ -1,0 +1,24 @@
+package banning
+
+import (
+	"errors"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
+	"unicode/utf8"
+)
+
+type utf8Checker struct {
+}
+
+func (c utf8Checker) Check(info metainfo.Info) error {
+	checkUtf8Strings := make([]string, 0, len(info.Files)+1)
+	checkUtf8Strings = append(checkUtf8Strings, info.BestName())
+	for _, file := range info.Files {
+		checkUtf8Strings = append(checkUtf8Strings, file.DisplayPath(&info))
+	}
+	for _, str := range checkUtf8Strings {
+		if !utf8.ValidString(str) {
+			return errors.New("meta info contains an invalid utf8 string")
+		}
+	}
+	return nil
+}

--- a/internal/protocol/metainfo/metainfofx/module.go
+++ b/internal/protocol/metainfo/metainfofx/module.go
@@ -2,6 +2,7 @@ package metainfofx
 
 import (
 	"github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config/configfx"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo/banning"
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo/metainforequester"
 	"go.uber.org/fx"
 )
@@ -12,6 +13,7 @@ func New() fx.Option {
 		configfx.NewConfigModule[metainforequester.Config]("metainfo_requester", metainforequester.NewDefaultConfig()),
 		fx.Provide(
 			metainforequester.New,
+			banning.New,
 		),
 	)
 }

--- a/internal/protocol/metainfo/parse.go
+++ b/internal/protocol/metainfo/parse.go
@@ -6,7 +6,6 @@ import (
 	"github.com/anacrolix/torrent/bencode"
 	mi "github.com/anacrolix/torrent/metainfo"
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
-	"unicode/utf8"
 )
 
 func ParseMetaInfoBytes(infoHash protocol.ID, metaInfoBytes []byte) (Info, error) {
@@ -16,16 +15,6 @@ func ParseMetaInfoBytes(infoHash protocol.ID, metaInfoBytes []byte) (Info, error
 	var info Info
 	if unmarshalErr := bencode.Unmarshal(metaInfoBytes, &info); unmarshalErr != nil {
 		return Info{}, fmt.Errorf("error unmarshaling info bytes: %s", unmarshalErr)
-	}
-	checkUtf8Strings := make([]string, 0, len(info.Files)+1)
-	checkUtf8Strings = append(checkUtf8Strings, info.BestName())
-	for _, file := range info.Files {
-		checkUtf8Strings = append(checkUtf8Strings, file.DisplayPath(&info))
-	}
-	for _, str := range checkUtf8Strings {
-		if !utf8.ValidString(str) {
-			return Info{}, errors.New("meta info contains an invalid utf8 string")
-		}
 	}
 	return info, nil
 }


### PR DESCRIPTION
Torrents meeting the following criteria will be rejected by the DHT crawler:

- Name contains keywords associated with CSAM
- Name is shorter than 8 characters
- Size is smaller than 1KB
- Name or filenames contain invalid UTF-8 strings