### PR TITLE
Add support for connecting to Redis cluster with TLS.

### DIFF
--- a/internal/redis/redisconfig/config.go
+++ b/internal/redis/redisconfig/config.go
@@ -1,8 +1,11 @@
 package redisconfig
 
 import (
-	redis "github.com/redis/go-redis/v9"
+	"crypto/tls"
+	"strings"
 	"time"
+
+	redis "github.com/redis/go-redis/v9"
 )
 
 func NewDefaultConfig() Config {
@@ -59,18 +62,37 @@ type Config struct {
 	// Maximum number of socket connections.
 	// Default is 10 connections per every CPU as reported by runtime.NumCPU.
 	PoolSize int
+
+	// Enable TLS for connection. Only used when Network is "tcp".
+	// Default is false.
+	TLS bool
 }
 
 func (c Config) RedisClientOptions() *redis.Options {
-	return &redis.Options{
-		Network:      c.Network,
-		Addr:         c.Addr,
-		Username:     c.Username,
-		Password:     c.Password,
-		DB:           c.DB,
-		DialTimeout:  c.DialTimeout,
-		ReadTimeout:  c.ReadTimeout,
-		WriteTimeout: c.WriteTimeout,
-		PoolSize:     c.PoolSize,
+	if c.TLS == false || c.Network != "tcp" {
+		return &redis.Options{
+			Network:      c.Network,
+			Addr:         c.Addr,
+			Username:     c.Username,
+			Password:     c.Password,
+			DB:           c.DB,
+			DialTimeout:  c.DialTimeout,
+			ReadTimeout:  c.ReadTimeout,
+			WriteTimeout: c.WriteTimeout,
+			PoolSize:     c.PoolSize,
+		}
+	} else {
+		return &redis.Options{
+			Network:      c.Network,
+			Addr:         c.Addr,
+			Username:     c.Username,
+			Password:     c.Password,
+			DB:           c.DB,
+			DialTimeout:  c.DialTimeout,
+			ReadTimeout:  c.ReadTimeout,
+			WriteTimeout: c.WriteTimeout,
+			PoolSize:     c.PoolSize,
+			TLSConfig:    &tls.Config{ServerName: strings.Split(c.Addr, ":")[0]},
+		}
 	}
 }


### PR DESCRIPTION
I want to add this option for a selfish reason, as my use case involves a Redis cluster hosted externally with TLS encryption.

This basic config enables TLS with all the default settings by Go and uses the `Addr` as TLS's `ServerName` for verification.

I am a total newbie on Go, so this will likely be a low-quality PR.

Great project, by the way.
It has been running very stable on my setup, and I have cooked up an Ansible script for Ubuntu that uses `AppArmor` and `systemd` for sandboxing.
I want to contribute some of my configs to the project, if you don't mind.