### PR TITLE
Add client suffix to DHT node ID

### DIFF
--- a/internal/dhtcrawler/infohash_triage.go
+++ b/internal/dhtcrawler/infohash_triage.go
@@ -25,7 +25,6 @@ func (c *crawler) runInfoHashTriage(ctx context.Context) {
 			reqMap := make(map[protocol.ID]nodeHasPeersForHash, len(reqs))
 			for _, r := range reqs {
 				if _, ok := reqMap[r.infoHash]; ok {
-					c.logger.Warnf("duplicate infohash triage: %s", r.infoHash)
 					continue
 				}
 				allHashes = append(allHashes, r.infoHash)
@@ -36,7 +35,6 @@ func (c *crawler) runInfoHashTriage(ctx context.Context) {
 				c.logger.Errorf("failed to filter infohashes: %s", filterErr.Error())
 				break
 			}
-			c.logger.Warnf("filteredHashes: %d / %d", len(allHashes), len(filteredHashes))
 			if len(filteredHashes) == 0 {
 				break
 			}

--- a/internal/dhtcrawler/persist.go
+++ b/internal/dhtcrawler/persist.go
@@ -23,7 +23,6 @@ func (c *crawler) runPersistTorrents(ctx context.Context) {
 			hashMap := make(map[protocol.ID]infoHashWithMetaInfo, len(is))
 			for _, i := range is {
 				if _, ok := hashMap[i.infoHash]; ok {
-					c.logger.Warnf("duplicate infohash: %s", i.infoHash)
 					continue
 				}
 				hashMap[i.infoHash] = i
@@ -130,7 +129,6 @@ func (c *crawler) runPersistSources(ctx context.Context) {
 			hashSet := make(map[protocol.ID]struct{}, len(scrapes))
 			for _, s := range scrapes {
 				if _, ok := hashSet[s.infoHash]; ok {
-					c.logger.Warnf("duplicate infohash scrape: %s", s.infoHash)
 					continue
 				}
 				hashSet[s.infoHash] = struct{}{}

--- a/internal/dhtcrawler/request_meta_info.go
+++ b/internal/dhtcrawler/request_meta_info.go
@@ -44,7 +44,6 @@ func (c *crawler) doRequestMetaInfo(
 			continue
 		}
 		if banErr := c.banningChecker.Check(res.Info); banErr != nil {
-			c.logger.Warnf("banning torrent '%s': %s", res.Info.BestName(), banErr)
 			_ = c.blockingManager.Block(ctx, []protocol.ID{hash})
 			return metainforequester.Response{}, banErr
 		}

--- a/internal/protocol/dht/dhtfx/module.go
+++ b/internal/protocol/dht/dhtfx/module.go
@@ -18,7 +18,7 @@ func New() fx.Option {
 			fx.Annotated{
 				Name: "dht_node_id",
 				Target: func() protocol.ID {
-					return protocol.RandomNodeID()
+					return protocol.RandomNodeIDWithClientSuffix()
 				},
 			},
 			client.New,


### PR DESCRIPTION
- For the DHT node ID we use a random byte string with the client ID encoded at the end, to allow identifying other bitmagnet instances in the wild.
- Remove some inadvertent logger warns