### PR TITLE
Use larger siglen for search_string GiST indexes

### DIFF
--- a/migrations/00006_gist_siglen_indexes.sql
+++ b/migrations/00006_gist_siglen_indexes.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+
+create index if not exists torrent_contents_search_string_344_idx on torrent_contents using gist (search_string gist_trgm_ops(siglen=344));
+create index if not exists content_search_string_168_idx on content using gist (search_string gist_trgm_ops(siglen=168));
+
+drop index if exists torrent_contents_search_string_idx;
+drop index if exists content_search_string_idx;
+
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+drop index if exists torrent_contents_search_string_344_idx;
+drop index if exists content_search_string_168_idx;
+
+create index if not exists torrent_contents_search_string_idx on torrent_contents using gist (id gist_trgm_ops);
+create index if not exists content_search_string_idx on content using gist (id gist_trgm_ops);
+
+-- +goose StatementEnd


### PR DESCRIPTION
Summarizing my findings from the Discord channel.

My queries via the web UI and torznab were taking exceptionally long with about 7 million records. Even with the database being read from L2ARC on a ZFS filesystem, queries would take a couple minutes when cold. The biggest performance issue was number of buffers read from the `torrent_contents.search_string LIKE %foo%` full text search query.

The [guidance online](https://alexklibisz.com/2022/02/18/optimizing-postgres-trigram-searc) recommends indexing for a query like this using trigram operators and GiST, which bitmagnet was already doing. However, the index was using a default signature length of 12 bytes(?). Experimenting with indexes using larger signature lengths, I found that the full text search portion of the query could be over **10x more performant** when it comes to buffers read and query time when warm (ARC cached), and solve my torznab queries timing out when cold (L2ARC cached).

There's no documentation online as to how to choose an optimal signature length. Since the signature bits are generated based on the words in the `search_string` trigram set, I found the largest trigram set for `torrent_contents.search_string` in my database, which was 344 for a `search_string` containing a 360 character hash. I tested and index with this value, and others around it, and 344 indeed seemed to be the sweet spot. This may be pure coincidence however. **The `siglen=344` index took about 5 minutes to create on my database, so it is something to be considered after updating.** Also, I found that my `torrent_contents_search_string_344_idx ` was actually smaller than the existing `torrent_contents_search_string_idx`, at 1.5GB vs 1.9GB.

As for the `content.search_string`, it is a much smaller table, and doesn't really have the same performance issues. I did the same trigram analysis and found the longest trigram set to be 168, for a `search_string` containing a 218 character long torrent name. Testing this signature length wasn't as conclusive. I found better performance at values of 768, and 512, and abysmal performance at 128 and 256. Ultimately the difference between 768, 512, and 168 is negligible and much better than the existing default index, so I set it to 168 for now.
