### PR TITLE
Video classifier fixes

### DIFF
--- a/internal/classifier/video/classifier.go
+++ b/internal/classifier/video/classifier.go
@@ -47,6 +47,9 @@ func (c videoClassifier) Classify(ctx context.Context, t model.Torrent) (classif
 	if cl.Content != nil {
 		cl.ContentType = model.NewNullContentType(cl.Content.Type)
 	}
+	if !cl.ContentType.Valid {
+		return classifier.Classification{}, classifier.ErrNoMatch
+	}
 	return cl, nil
 }
 

--- a/internal/classifier/video/parse_test.go
+++ b/internal/classifier/video/parse_test.go
@@ -96,7 +96,7 @@ func TestParse(t *testing.T) {
 				title:       "1776",
 				releaseYear: 1979,
 				attrs: classifier.ContentAttributes{
-					VideoResolution: model.NewNullVideoResolution(model.VideoResolutionV1080p),
+					VideoResolution: model.NewNullVideoResolution(model.VideoResolutionV720p),
 					VideoSource:     model.NewNullVideoSource(model.VideoSourceBluRay),
 					VideoCodec:      model.NewNullVideoCodec(model.VideoCodecX264),
 					ReleaseGroup: model.NullString{

--- a/internal/model/video_resolution.go
+++ b/internal/model/video_resolution.go
@@ -18,12 +18,13 @@ var videoResolutionAliases = map[string]VideoResolution{
 	"1080i":     VideoResolutionV1080p,
 	"1920x1080": VideoResolutionV1080p,
 	"3840x2160": VideoResolutionV2160p,
-	"8k":        VideoResolutionV4320p,
-	"4k":        VideoResolutionV2160p,
-	"uhd":       VideoResolutionV2160p,
 	"2k":        VideoResolutionV1440p,
-	"hd":        VideoResolutionV1080p,
+	"4k":        VideoResolutionV2160p,
+	"8k":        VideoResolutionV4320p,
 	"sd":        VideoResolutionV480p,
+	"hd":        VideoResolutionV720p,
+	"fhd":       VideoResolutionV1080p,
+	"uhd":       VideoResolutionV2160p,
 }
 
 func createVideoResolutionRegex() *regexp.Regexp {

--- a/internal/model/video_resolution.go
+++ b/internal/model/video_resolution.go
@@ -18,7 +18,7 @@ var videoResolutionAliases = map[string]VideoResolution{
 	"1080i":     VideoResolutionV1080p,
 	"1920x1080": VideoResolutionV1080p,
 	"3840x2160": VideoResolutionV2160p,
-	"2k":        VideoResolutionV1440p,
+	"2k":        VideoResolutionV1080p,
 	"4k":        VideoResolutionV2160p,
 	"8k":        VideoResolutionV4320p,
 	"sd":        VideoResolutionV480p,


### PR DESCRIPTION
- Don't set video attributes of unknown content
- Add/fix video resolution aliases