### PR TITLE
Reprocess tweaks

### DIFF
--- a/internal/app/cmd/torrentcmd/command.go
+++ b/internal/app/cmd/torrentcmd/command.go
@@ -33,10 +33,6 @@ func New(p Params) (Result, error) {
 					&cli.StringSliceFlag{
 						Name: "infoHash",
 					},
-					&cli.BoolFlag{
-						Name:  "rematch",
-						Value: false,
-					},
 				},
 				Action: func(ctx *cli.Context) error {
 					pr, err := p.Processor.Get()
@@ -55,8 +51,8 @@ func New(p Params) (Result, error) {
 						return err
 					}
 					return pr.Process(ctx.Context, processor.MessageParams{
-						Rematch:    ctx.Bool("rematch"),
-						InfoHashes: infoHashes,
+						ClassifyMode: processor.ClassifyModeRematch,
+						InfoHashes:   infoHashes,
 					})
 				},
 			},

--- a/internal/classifier/factory.go
+++ b/internal/classifier/factory.go
@@ -29,7 +29,7 @@ func New(p Params) Result {
 				}
 				subClassifiers = append(subClassifiers, r)
 			}
-			subClassifiers = append(subClassifiers, fallbackClassifier{})
+			subClassifiers = append(subClassifiers, FallbackClassifier{})
 			sort.Slice(subClassifiers, func(i, j int) bool {
 				return subClassifiers[i].Priority() < subClassifiers[j].Priority()
 			})

--- a/internal/classifier/fallback.go
+++ b/internal/classifier/fallback.go
@@ -6,17 +6,17 @@ import (
 	"math"
 )
 
-type fallbackClassifier struct{}
+type FallbackClassifier struct{}
 
-func (c fallbackClassifier) Key() string {
+func (c FallbackClassifier) Key() string {
 	return "fallback"
 }
 
-func (c fallbackClassifier) Priority() int {
+func (c FallbackClassifier) Priority() int {
 	return math.MaxInt
 }
 
-func (c fallbackClassifier) Classify(_ context.Context, t model.Torrent) (Classification, error) {
+func (c FallbackClassifier) Classify(_ context.Context, t model.Torrent) (Classification, error) {
 	cl := Classification{}
 	cl.ApplyHint(t.Hint)
 	return cl, nil

--- a/internal/processor/asynq/decorator/0.5.0_upgrade.go
+++ b/internal/processor/asynq/decorator/0.5.0_upgrade.go
@@ -87,7 +87,8 @@ func New(p Params) (Result, error) {
 										infoHashes = append(infoHashes, c.InfoHash)
 									}
 									if _, err := p.Publish(ctx, processor.MessageParams{
-										InfoHashes: infoHashes,
+										ClassifyMode: processor.ClassifyModeSkipUnmatched,
+										InfoHashes:   infoHashes,
 									}); err != nil {
 										return err
 									}

--- a/internal/processor/message.go
+++ b/internal/processor/message.go
@@ -6,7 +6,21 @@ import (
 
 const MessageName = "process_torrent"
 
+type ClassifyMode int
+
+const (
+	// ClassifyModeDefault will use any pre-existing content match as a hint
+	// This is the most common use case and will only attempt to match previously unmatched torrents
+	ClassifyModeDefault ClassifyMode = iota
+	// ClassifyModeRematch will ignore any pre-existing classification and always classify from scratch
+	// This is useful if there are errors in matches from an earlier version that need to be corrected
+	ClassifyModeRematch
+	// ClassifyModeSkipUnmatched will skip classification for previously unmatched torrents (that don't have any hint)
+	// This is useful for eliminating expensive API calls while running the rest of the processing pipeline
+	ClassifyModeSkipUnmatched
+)
+
 type MessageParams struct {
-	Rematch    bool
-	InfoHashes []protocol.ID
+	ClassifyMode ClassifyMode
+	InfoHashes   []protocol.ID
 }


### PR DESCRIPTION
Tweaking the 0.5.0 upgrade process to avoid unnecessary work. This involves adding a `classifyMode` parameter to be used by the processing pipeline.

The mode can be one of:

- `default`: Will use any pre-existing content match as a hint: this is the most common use case and will only attempt to match previously unmatched torrents.
- `rematch`: Will ignore any pre-existing classification and always classify from scratch: this is useful if there are errors in matches from an earlier version that need to be corrected.
- `skip`: This mode will be used for the 0.5.0 upgrade. It will skip classification for previously unmatched torrents (that don't have any hint). This is useful for eliminating expensive API calls while running the rest of the processing pipeline.