### PR TITLE
Torrent processor optimisations

### DIFF
--- a/internal/processor/factory.go
+++ b/internal/processor/factory.go
@@ -42,6 +42,7 @@ func New(p Params) Result {
 				classifier:       c,
 				dao:              d,
 				search:           s,
+				processSemaphore: semaphore.NewWeighted(2),
 				persistSemaphore: semaphore.NewWeighted(1),
 			}, nil
 		}),

--- a/internal/processor/persist.go
+++ b/internal/processor/persist.go
@@ -41,7 +41,7 @@ func (c processor) Persist(ctx context.Context, torrentContents ...model.Torrent
 			if createContentErr := tx.Content.WithContext(ctx).Clauses(
 				clause.OnConflict{
 					UpdateAll: true,
-				}).CreateInBatches(contentsPtr, 100); createContentErr != nil {
+				}).CreateInBatches(contentsPtr, 20); createContentErr != nil {
 				return createContentErr
 			}
 		}
@@ -54,6 +54,6 @@ func (c processor) Persist(ctx context.Context, torrentContents ...model.Torrent
 			clause.OnConflict{
 				DoNothing: true,
 			},
-		).CreateInBatches(torrentContentsPtr, 100)
+		).CreateInBatches(torrentContentsPtr, 20)
 	})
 }


### PR DESCRIPTION
- Limit concurrency for processing torrents
- Don't fetch unneeded relations when processing torrents
- Reduce batch size for persisting torrent content
- Optimise queries for getting content by ID