### PR TITLE
Add systemd service example

### DIFF
--- a/bitmagnet.service
+++ b/bitmagnet.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=Bitmagnet indexer and crawler
+After=network.target
+
+[Service]
+User=bitmagnet
+Group=bitmagnet
+ExecStart=/usr/bin/bitmagnet worker run --all
+Restart=on-failure
+RestartSec=15s
+UMask=0077
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateMounts=true
+PrivateTmp=true
+PrivateUsers=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=true
+# AF_UNIX for postgres unix socket if you use it
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
If you want to run it 24/7 as proper systemd service then it's useful to have `.service`. I tried to harden it as much as possible, only few things could be tweaked more like `SystemCallFilter` but this already should be good enough.

```
$ systemd-analyze security bitmagnet
[...]
→ Overall exposure level for bitmagnet.service: 1.2 OK 🙂 (lower number means most secure, 10 is most unsafe) 
```

And here's bonus nginx config
```
upstream bitmagnet {
    server 127.0.0.1:3333;
}

server {
    listen 443 ssl;

    server_name bitmagnet.example.org;

    access_log  /var/log/nginx/bitmagnet.access.log;
    error_log   /var/log/nginx/bitmagnet.error.log;

    # Consider using some auth if you want allow non-local
    allow 127.0.0.0/8;
    allow ::1/128;
    deny all;

    ssl_certificate "/etc/letsencrypt/live/bitmagnet.example.org/fullchain.pem";
    ssl_certificate_key "/etc/letsencrypt/live/bitmagnet.example.org/privkey.pem";
    ssl_trusted_certificate "/etc/letsencrypt/live/bitmagnet.example.org/chain.pem";

    ssl_stapling on;
    ssl_stapling_verify on;
    add_header Strict-Transport-Security "max-age=31536000" always;
    add_header X-Frame-Options "DENY";
    add_header X-Content-Type-Options "nosniff";
    add_header Content-Security-Policy "default-src 'self' https:; object-src 'none; frame-src 'none'; base-uri 'self'; img-src https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; worker-src 'self'; connect-src https:; sandbox allow-same-origin allow-scripts allow-downloads; trusted-types; require-trusted-types-for 'script';

    location / {
        proxy_pass http://bitmagnet;
        include config/proxy.conf;
    }

}

```