### PR TITLE
Fix importer handling of unclosed connection

### DIFF
--- a/internal/importer/httpserver/httpserver.go
+++ b/internal/importer/httpserver/httpserver.go
@@ -96,7 +96,7 @@ func (b builder) handle(ctx *gin.Context, i importer.Importer) {
 	}
 	for s.Scan() {
 		for _, ch := range s.Text() {
-			if ch == '\n' {
+			if ch == '\n' && len(currentLine) > 0 {
 				if err := addItem(); err != nil {
 					return
 				}
@@ -120,4 +120,5 @@ func (b builder) handle(ctx *gin.Context, i importer.Importer) {
 	}
 	ctx.Status(200)
 	writeCount()
+	_, _ = ctx.Writer.WriteString("import complete\n")
 }

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -141,7 +141,6 @@ func (i *activeImport) run(ctx context.Context) {
 }
 
 func (i *activeImport) buffer(item Item) {
-	i.wg.Add(1)
 	defer i.wg.Done()
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
@@ -265,6 +264,7 @@ func (i *activeImport) Import(items ...Item) error {
 		return ErrImportClosed
 	}
 	for _, item := range items {
+		i.wg.Add(1)
 		i.itemChan <- item
 	}
 	return nil


### PR DESCRIPTION
Fix https://github.com/bitmagnet-io/bitmagnet/issues/133
When importing a small number of items without closing the connection, the import buffer was not being flushed leaving the items unimported.