### PR TITLE
Fix bugs in log file rotator

### DIFF
--- a/internal/boilerplate/logging/logger.go
+++ b/internal/boilerplate/logging/logger.go
@@ -42,7 +42,7 @@ func New(params Params) Result {
 		levelToZapLevel(params.Config.Level),
 	)
 	if params.Config.FileRotator.Enabled {
-		fWriteSyncer := NewFileRotator(params.Config.FileRotator)
+		fWriteSyncer := newFileRotator(params.Config.FileRotator)
 		core = zapcore.NewTee(
 			core,
 			zapcore.NewCore(
@@ -53,7 +53,7 @@ func New(params Params) Result {
 		)
 		appHook = fx.Hook{
 			OnStop: func(context.Context) error {
-				return fWriteSyncer.Sync()
+				return fWriteSyncer.Close()
 			},
 		}
 	}


### PR DESCRIPTION
- Ensure path exists before writing to log file
- Don't attempt to write log file after logger is closed