### PR TITLE
Bump upload-artifact action

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -56,7 +56,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: digests
           path: /tmp/digests/*
@@ -69,7 +69,7 @@ jobs:
       - build
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: digests
           path: /tmp/digests


### PR DESCRIPTION
This PR bumps pload-artifact action to latest version, thus avoiding deprecation warnings as seem [here](https://github.com/bitmagnet-io/bitmagnet/actions/runs/7978985032).