### PR TITLE
Implement dhtcrawler.save_failed option to save failed torrents

### DIFF
--- a/internal/dhtcrawler/config.go
+++ b/internal/dhtcrawler/config.go
@@ -20,6 +20,9 @@ type Config struct {
 	SavePieces bool
 	// RescrapeThreshold is the amount of time that must pass before a torrent is rescraped to count seeders and leechers.
 	RescrapeThreshold time.Duration
+	// SaveFailed when true then torrents that fail to save to DB will be saved on disk
+	// useful to investigate failures
+	SaveFailed bool
 }
 
 func NewDefaultConfig() Config {

--- a/internal/dhtcrawler/crawler.go
+++ b/internal/dhtcrawler/crawler.go
@@ -42,6 +42,7 @@ type crawler struct {
 	rescrapeThreshold            time.Duration
 	saveFilesThreshold           uint
 	savePieces                   bool
+	saveFailed                   bool
 	dao                          *dao.Query
 	// ignoreHashes is a thread-safe bloom filter that the crawler keeps in memory, containing every hash it has already encountered.
 	// This avoids multiple attempts to crawl the same hash, and takes a lot of load off the database query that checks if a hash

--- a/internal/dhtcrawler/factory.go
+++ b/internal/dhtcrawler/factory.go
@@ -96,6 +96,7 @@ func New(params Params) Result {
 						saveFilesThreshold: params.Config.SaveFilesThreshold,
 						savePieces:         params.Config.SavePieces,
 						rescrapeThreshold:  params.Config.RescrapeThreshold,
+						saveFailed:         params.Config.SaveFailed,
 						dao:                query,
 						ignoreHashes: &ignoreHashes{
 							bloom: boom.NewStableBloomFilter(10_000_000, 2, 0.001),

--- a/internal/dhtcrawler/persist.go
+++ b/internal/dhtcrawler/persist.go
@@ -72,6 +72,7 @@ func (c *crawler) runPersistTorrents(ctx context.Context) {
 				return nil
 			}); persistErr != nil {
 				c.logger.Errorf("error persisting torrents: %s", persistErr)
+				c.saveTorrentsInfo(is);
 			} else {
 				c.persistedTotal.With(prometheus.Labels{"entity": "Torrent"}).Add(float64(len(ts)))
 				c.logger.Debugw("persisted torrents", "count", len(ts))

--- a/internal/dhtcrawler/persist_debug.go
+++ b/internal/dhtcrawler/persist_debug.go
@@ -1,0 +1,36 @@
+package dhtcrawler
+
+import (
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/adrg/xdg"
+	"os"
+	"path"
+)
+
+func (c *crawler) saveTorrentsInfo(torrentsInfo []infoHashWithMetaInfo) {
+	if (c.saveFailed) {
+		for _, info := range torrentsInfo {
+			torrentsFolder := path.Join(xdg.StateHome, "bitmagnet", "torrents")
+			err := os.MkdirAll(torrentsFolder, 0755)
+			if err != nil {
+				c.logger.Errorf("failed to create folder for torrents! Error %s", err)
+				return
+			}
+
+			torrentFile := path.Join(torrentsFolder, info.infoHash.String() + ".torrent")
+			io, err := os.Create(torrentFile)
+			if err != nil {
+				c.logger.Errorf("failed to create torrent file! Error %s", err)
+				return
+			}
+
+			encoder := bencode.NewEncoder(io)
+			encoder.Encode(info.metaInfo)
+
+			if err := io.Close(); err != nil {
+				c.logger.Errorf("failed to close file! Error %s", err)
+			}
+			c.logger.Errorf("saved %s", torrentFile)
+		}
+	}
+}


### PR DESCRIPTION
Persisting to DB can fail due to various reasons so to make it easier to debug those allow saving failed torrents to disk for further inspection. This will make it easier to fix issues like #127 and you won't lose torrent data because once bug is fixed these could be redriven back (needs additional import support).

For now to inspect these files can use [fastbencode](https://github.com/breezy-team/fastbencode) like this

```
$ python -c 'import sys,pprint,fastbencode; pprint.pp(fastbencode.bdecode(sys.stdin.buffer.read()))' < infohash.torrent
```
