### PR TITLE
Parallel search strategies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/99designs/gqlgen v0.17.45
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/abice/go-enum v0.6.0
 	github.com/adrg/xdg v0.4.0
 	github.com/agnivade/levenshtein v1.1.1
@@ -47,6 +48,7 @@ require (
 	golang.org/x/time v0.5.0
 	google.golang.org/protobuf v1.34.0
 	gopkg.in/yaml.v3 v3.0.1
+	gorm.io/driver/mysql v1.5.6
 	gorm.io/driver/postgres v1.5.7
 	gorm.io/gen v0.3.26
 	gorm.io/gorm v1.25.10
@@ -169,6 +171,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/datatypes v1.2.0 // indirect
-	gorm.io/driver/mysql v1.5.6 // indirect
 	gorm.io/hints v1.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/99designs/gqlgen v0.17.45 h1:bH0AH67vIJo8JKNKPJP+pOPpQhZeuVRQLf53dKIpDik=
 github.com/99designs/gqlgen v0.17.45/go.mod h1:Bas0XQ+Jiu/Xm5E33jC8sES3G+iC2esHBMXcq0fUPs0=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
@@ -281,6 +283,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.17.3/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
 github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=

--- a/internal/database/dao/torrent_contents.gen.go
+++ b/internal/database/dao/torrent_contents.gen.go
@@ -46,6 +46,8 @@ func newTorrentContent(db *gorm.DB, opts ...gen.DOOption) torrentContent {
 	_torrentContent.Seeders = field.NewField(tableName, "seeders")
 	_torrentContent.Leechers = field.NewField(tableName, "leechers")
 	_torrentContent.PublishedAt = field.NewTime(tableName, "published_at")
+	_torrentContent.Size = field.NewUint(tableName, "size")
+	_torrentContent.FilesCount = field.NewField(tableName, "files_count")
 	_torrentContent.Torrent = torrentContentBelongsToTorrent{
 		db: db.Session(&gorm.Session{}),
 
@@ -155,6 +157,8 @@ type torrentContent struct {
 	Seeders         field.Field
 	Leechers        field.Field
 	PublishedAt     field.Time
+	Size            field.Uint
+	FilesCount      field.Field
 	Torrent         torrentContentBelongsToTorrent
 
 	Content torrentContentBelongsToContent
@@ -193,6 +197,8 @@ func (t *torrentContent) updateTableName(table string) *torrentContent {
 	t.Seeders = field.NewField(table, "seeders")
 	t.Leechers = field.NewField(table, "leechers")
 	t.PublishedAt = field.NewTime(table, "published_at")
+	t.Size = field.NewUint(table, "size")
+	t.FilesCount = field.NewField(table, "files_count")
 
 	t.fillFieldMap()
 
@@ -209,7 +215,7 @@ func (t *torrentContent) GetFieldByName(fieldName string) (field.OrderExpr, bool
 }
 
 func (t *torrentContent) fillFieldMap() {
-	t.fieldMap = make(map[string]field.Expr, 21)
+	t.fieldMap = make(map[string]field.Expr, 23)
 	t.fieldMap["id"] = t.ID
 	t.fieldMap["info_hash"] = t.InfoHash
 	t.fieldMap["content_type"] = t.ContentType
@@ -229,6 +235,8 @@ func (t *torrentContent) fillFieldMap() {
 	t.fieldMap["seeders"] = t.Seeders
 	t.fieldMap["leechers"] = t.Leechers
 	t.fieldMap["published_at"] = t.PublishedAt
+	t.fieldMap["size"] = t.Size
+	t.fieldMap["files_count"] = t.FilesCount
 
 }
 

--- a/internal/database/dao/torrent_files.gen.go
+++ b/internal/database/dao/torrent_files.gen.go
@@ -28,10 +28,10 @@ func newTorrentFile(db *gorm.DB, opts ...gen.DOOption) torrentFile {
 	tableName := _torrentFile.torrentFileDo.TableName()
 	_torrentFile.ALL = field.NewAsterisk(tableName)
 	_torrentFile.InfoHash = field.NewField(tableName, "info_hash")
-	_torrentFile.Index = field.NewUint32(tableName, "index")
+	_torrentFile.Index = field.NewUint(tableName, "index")
 	_torrentFile.Path = field.NewString(tableName, "path")
 	_torrentFile.Extension = field.NewString(tableName, "extension")
-	_torrentFile.Size = field.NewUint64(tableName, "size")
+	_torrentFile.Size = field.NewUint(tableName, "size")
 	_torrentFile.CreatedAt = field.NewTime(tableName, "created_at")
 	_torrentFile.UpdatedAt = field.NewTime(tableName, "updated_at")
 
@@ -45,10 +45,10 @@ type torrentFile struct {
 
 	ALL       field.Asterisk
 	InfoHash  field.Field
-	Index     field.Uint32
+	Index     field.Uint
 	Path      field.String
 	Extension field.String
-	Size      field.Uint64
+	Size      field.Uint
 	CreatedAt field.Time
 	UpdatedAt field.Time
 
@@ -68,10 +68,10 @@ func (t torrentFile) As(alias string) *torrentFile {
 func (t *torrentFile) updateTableName(table string) *torrentFile {
 	t.ALL = field.NewAsterisk(table)
 	t.InfoHash = field.NewField(table, "info_hash")
-	t.Index = field.NewUint32(table, "index")
+	t.Index = field.NewUint(table, "index")
 	t.Path = field.NewString(table, "path")
 	t.Extension = field.NewString(table, "extension")
-	t.Size = field.NewUint64(table, "size")
+	t.Size = field.NewUint(table, "size")
 	t.CreatedAt = field.NewTime(table, "created_at")
 	t.UpdatedAt = field.NewTime(table, "updated_at")
 

--- a/internal/database/dao/torrents.gen.go
+++ b/internal/database/dao/torrents.gen.go
@@ -29,7 +29,7 @@ func newTorrent(db *gorm.DB, opts ...gen.DOOption) torrent {
 	_torrent.ALL = field.NewAsterisk(tableName)
 	_torrent.InfoHash = field.NewField(tableName, "info_hash")
 	_torrent.Name = field.NewString(tableName, "name")
-	_torrent.Size = field.NewUint64(tableName, "size")
+	_torrent.Size = field.NewUint(tableName, "size")
 	_torrent.Private = field.NewBool(tableName, "private")
 	_torrent.CreatedAt = field.NewTime(tableName, "created_at")
 	_torrent.UpdatedAt = field.NewTime(tableName, "updated_at")
@@ -88,7 +88,7 @@ type torrent struct {
 	ALL         field.Asterisk
 	InfoHash    field.Field
 	Name        field.String
-	Size        field.Uint64
+	Size        field.Uint
 	Private     field.Bool
 	CreatedAt   field.Time
 	UpdatedAt   field.Time
@@ -124,7 +124,7 @@ func (t *torrent) updateTableName(table string) *torrent {
 	t.ALL = field.NewAsterisk(table)
 	t.InfoHash = field.NewField(table, "info_hash")
 	t.Name = field.NewString(table, "name")
-	t.Size = field.NewUint64(table, "size")
+	t.Size = field.NewUint(table, "size")
 	t.Private = field.NewBool(table, "private")
 	t.CreatedAt = field.NewTime(table, "created_at")
 	t.UpdatedAt = field.NewTime(table, "updated_at")

--- a/internal/database/exclause/LICENSE
+++ b/internal/database/exclause/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 WinterYukky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/database/exclause/doc.go
+++ b/internal/database/exclause/doc.go
@@ -1,0 +1,4 @@
+// module copied from https://github.com/WinterYukky/gorm-extra-clause-plugin
+// with added support for materialized CTE
+
+package exclause

--- a/internal/database/exclause/except.go
+++ b/internal/database/exclause/except.go
@@ -1,0 +1,63 @@
+package exclause
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Except is except clause
+type Except struct {
+	Statements []clause.Expression
+}
+
+// Name except clause name
+func (except Except) Name() string {
+	return "EXCEPT"
+}
+
+// Build build except clause
+func (except Except) Build(builder clause.Builder) {
+	for index, statement := range except.Statements {
+		if index != 0 {
+			builder.WriteString(" EXCEPT ")
+		}
+		statement.Build(builder)
+	}
+}
+
+// MergeClause merge Except clauses
+func (except Except) MergeClause(mergeClause *clause.Clause) {
+	if u, ok := mergeClause.Expression.(Except); ok {
+		statements := make([]clause.Expression, len(u.Statements)+len(except.Statements))
+		copy(statements, u.Statements)
+		copy(statements[len(u.Statements):], except.Statements)
+		except.Statements = statements
+	}
+
+	mergeClause.Expression = except
+}
+
+// NewExcept is easy to create new Except
+//
+//	// examples
+//	// SELECT * FROM `general_users` EXCEPT SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewExcept("SELECT * FROM `admin_users`")).Scan(&users)
+//
+//	// SELECT * FROM `general_users` EXCEPT SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewExcept(db.Table("admin_users"))).Scan(&users)
+//
+//	// SELECT * FROM `general_users` EXCEPT ALL SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewExcept("ALL ?", db.Table("admin_users"))).Scan(&users)
+func NewExcept(query interface{}, args ...interface{}) Except {
+	switch v := query.(type) {
+	case *gorm.DB:
+		return Except{
+			Statements: []clause.Expression{Subquery{DB: v}},
+		}
+	case string:
+		return Except{
+			Statements: []clause.Expression{clause.Expr{SQL: v, Vars: args}},
+		}
+	}
+	return Except{}
+}

--- a/internal/database/exclause/except.go
+++ b/internal/database/exclause/except.go
@@ -19,7 +19,9 @@ func (except Except) Name() string {
 func (except Except) Build(builder clause.Builder) {
 	for index, statement := range except.Statements {
 		if index != 0 {
-			builder.WriteString(" EXCEPT ")
+			if _, err := builder.WriteString(" EXCEPT "); err != nil {
+				panic(err)
+			}
 		}
 		statement.Build(builder)
 	}

--- a/internal/database/exclause/except_test.go
+++ b/internal/database/exclause/except_test.go
@@ -1,0 +1,161 @@
+package exclause
+
+import (
+	"database/sql/driver"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestExcept_Query(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(db *gorm.DB) *gorm.DB
+		want      string
+		wantErr   bool
+		wantArgs  []driver.Value
+	}{
+		{
+			name: "When statement is clause.Expr, then should be used as statement",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Except{
+						Statements: []clause.Expression{
+							clause.Expr{
+								SQL:  "ALL ?",
+								Vars: []interface{}{db.Table("admin_users")},
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` EXCEPT ALL SELECT * FROM `admin_users`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When statement is exclause.Subquery, then should be used as statement",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Except{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("admin_users"),
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` EXCEPT SELECT * FROM `admin_users`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When has multiple EXCEPT, then should be used all EXCEPT clause",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Except{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("admin_users"),
+							},
+						},
+					}).
+					Clauses(Except{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("guest_users"),
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` EXCEPT SELECT * FROM `admin_users` EXCEPT SELECT * FROM `guest_users`",
+			wantArgs: []driver.Value{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db, _ := gorm.Open(mysql.New(mysql.Config{
+				Conn:                      mockDB,
+				SkipInitializeWithVersion: true,
+			}))
+			db.Use(New())
+			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
+
+			if tt.operation != nil {
+				db = tt.operation(db)
+			}
+			if db.Error != nil {
+				t.Errorf(db.Error.Error())
+			}
+		})
+	}
+}
+
+func TestNewExcept(t *testing.T) {
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+	db, _ := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      mockDB,
+		SkipInitializeWithVersion: true,
+	}))
+	db = db.Table("users")
+	type args struct {
+		subquery interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want Except
+	}{
+		{
+			name: "When subquery is *gorm.DB, then statement is exclause.Subquery",
+			args: args{
+				subquery: db,
+			},
+			want: Except{
+				Statements: []clause.Expression{
+					Subquery{
+						DB: db,
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is string, then statement is clause.Expr",
+			args: args{
+				subquery: "SELECT * FROM users",
+			},
+			want: Except{
+				Statements: []clause.Expression{
+					clause.Expr{
+						SQL: "SELECT * FROM users",
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is else, then statement is empty Except",
+			args: args{
+				subquery: 0,
+			},
+			want: Except{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewExcept(tt.args.subquery); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewExcept() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/database/exclause/except_test.go
+++ b/internal/database/exclause/except_test.go
@@ -85,7 +85,9 @@ func TestExcept_Query(t *testing.T) {
 				Conn:                      mockDB,
 				SkipInitializeWithVersion: true,
 			}))
-			db.Use(New())
+			if err := db.Use(New()); err != nil {
+				t.Fatalf("an error '%s' was not expected when using the database plugin", err)
+			}
 			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
 
 			if tt.operation != nil {

--- a/internal/database/exclause/intersect.go
+++ b/internal/database/exclause/intersect.go
@@ -1,0 +1,63 @@
+package exclause
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Intersect is intersect clause
+type Intersect struct {
+	Statements []clause.Expression
+}
+
+// Name intersect clause name
+func (intersect Intersect) Name() string {
+	return "INTERSECT"
+}
+
+// Build build intersect clause
+func (intersect Intersect) Build(builder clause.Builder) {
+	for index, statement := range intersect.Statements {
+		if index != 0 {
+			builder.WriteString(" INTERSECT ")
+		}
+		statement.Build(builder)
+	}
+}
+
+// MergeClause merge Intersect clauses
+func (intersect Intersect) MergeClause(mergeClause *clause.Clause) {
+	if u, ok := mergeClause.Expression.(Intersect); ok {
+		statements := make([]clause.Expression, len(u.Statements)+len(intersect.Statements))
+		copy(statements, u.Statements)
+		copy(statements[len(u.Statements):], intersect.Statements)
+		intersect.Statements = statements
+	}
+
+	mergeClause.Expression = intersect
+}
+
+// NewIntersect is easy to create new Intersect
+//
+//	// examples
+//	// SELECT * FROM `general_users` INTERSECT SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewIntersect("SELECT * FROM `admin_users`")).Scan(&users)
+//
+//	// SELECT * FROM `general_users` INTERSECT SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewIntersect(db.Table("admin_users"))).Scan(&users)
+//
+//	// SELECT * FROM `general_users` INTERSECT ALL SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewIntersect("ALL ?", db.Table("admin_users"))).Scan(&users)
+func NewIntersect(query interface{}, args ...interface{}) Intersect {
+	switch v := query.(type) {
+	case *gorm.DB:
+		return Intersect{
+			Statements: []clause.Expression{Subquery{DB: v}},
+		}
+	case string:
+		return Intersect{
+			Statements: []clause.Expression{clause.Expr{SQL: v, Vars: args}},
+		}
+	}
+	return Intersect{}
+}

--- a/internal/database/exclause/intersect.go
+++ b/internal/database/exclause/intersect.go
@@ -19,7 +19,9 @@ func (intersect Intersect) Name() string {
 func (intersect Intersect) Build(builder clause.Builder) {
 	for index, statement := range intersect.Statements {
 		if index != 0 {
-			builder.WriteString(" INTERSECT ")
+			if _, err := builder.WriteString(" INTERSECT "); err != nil {
+				panic(err)
+			}
 		}
 		statement.Build(builder)
 	}

--- a/internal/database/exclause/intersect_test.go
+++ b/internal/database/exclause/intersect_test.go
@@ -1,0 +1,161 @@
+package exclause
+
+import (
+	"database/sql/driver"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestIntersect_Query(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(db *gorm.DB) *gorm.DB
+		want      string
+		wantErr   bool
+		wantArgs  []driver.Value
+	}{
+		{
+			name: "When statement is clause.Expr, then should be used as statement",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Intersect{
+						Statements: []clause.Expression{
+							clause.Expr{
+								SQL:  "ALL ?",
+								Vars: []interface{}{db.Table("admin_users")},
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` INTERSECT ALL SELECT * FROM `admin_users`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When statement is exclause.Subquery, then should be used as statement",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Intersect{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("admin_users"),
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` INTERSECT SELECT * FROM `admin_users`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When has multiple INTERSECT, then should be used all INTERSECT clause",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Intersect{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("admin_users"),
+							},
+						},
+					}).
+					Clauses(Intersect{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("guest_users"),
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` INTERSECT SELECT * FROM `admin_users` INTERSECT SELECT * FROM `guest_users`",
+			wantArgs: []driver.Value{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db, _ := gorm.Open(mysql.New(mysql.Config{
+				Conn:                      mockDB,
+				SkipInitializeWithVersion: true,
+			}))
+			db.Use(New())
+			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
+
+			if tt.operation != nil {
+				db = tt.operation(db)
+			}
+			if db.Error != nil {
+				t.Errorf(db.Error.Error())
+			}
+		})
+	}
+}
+
+func TestNewIntersect(t *testing.T) {
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+	db, _ := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      mockDB,
+		SkipInitializeWithVersion: true,
+	}))
+	db = db.Table("users")
+	type args struct {
+		subquery interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want Intersect
+	}{
+		{
+			name: "When subquery is *gorm.DB, then statement is exclause.Subquery",
+			args: args{
+				subquery: db,
+			},
+			want: Intersect{
+				Statements: []clause.Expression{
+					Subquery{
+						DB: db,
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is string, then statement is clause.Expr",
+			args: args{
+				subquery: "SELECT * FROM users",
+			},
+			want: Intersect{
+				Statements: []clause.Expression{
+					clause.Expr{
+						SQL: "SELECT * FROM users",
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is else, then statement is empty Intersect",
+			args: args{
+				subquery: 0,
+			},
+			want: Intersect{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewIntersect(tt.args.subquery); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewIntersect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/database/exclause/intersect_test.go
+++ b/internal/database/exclause/intersect_test.go
@@ -85,7 +85,9 @@ func TestIntersect_Query(t *testing.T) {
 				Conn:                      mockDB,
 				SkipInitializeWithVersion: true,
 			}))
-			db.Use(New())
+			if err := db.Use(New()); err != nil {
+				t.Fatalf("an error '%s' was not expected when using the database plugin", err)
+			}
 			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
 
 			if tt.operation != nil {

--- a/internal/database/exclause/plugin.go
+++ b/internal/database/exclause/plugin.go
@@ -1,0 +1,30 @@
+package exclause
+
+import "gorm.io/gorm"
+
+// ExtraClausePlugin support plugin that not supported clause by gorm
+type ExtraClausePlugin struct{}
+
+// Name return plugin name
+func (e *ExtraClausePlugin) Name() string {
+	return "ExtraClausePlugin"
+}
+
+// Initialize register BuildClauses
+func (e *ExtraClausePlugin) Initialize(db *gorm.DB) error {
+	db.Callback().Query().Clauses = []string{
+		"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
+	}
+	db.Callback().Row().Clauses = []string{
+		"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
+	}
+	return nil
+}
+
+// New create new ExtraClausePlugin
+//
+//	// example
+//	db.Use(extraClausePlugin.New())
+func New() *ExtraClausePlugin {
+	return &ExtraClausePlugin{}
+}

--- a/internal/database/exclause/plugin_test.go
+++ b/internal/database/exclause/plugin_test.go
@@ -1,0 +1,30 @@
+package exclause
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func Test(t *testing.T) {
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+	db, _ := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      mockDB,
+		SkipInitializeWithVersion: true,
+	}))
+	err = db.Use(New())
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when registering the plugin", err)
+	}
+
+	_, ok := db.Plugins["ExtraClausePlugin"]
+	if !ok {
+		t.Errorf("Could not find ExtraClausePlugin after registration")
+	}
+}

--- a/internal/database/exclause/subquery.go
+++ b/internal/database/exclause/subquery.go
@@ -1,0 +1,16 @@
+package exclause
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Subquery is subquery statement
+type Subquery struct {
+	DB *gorm.DB
+}
+
+// Build build subquery
+func (subquery Subquery) Build(builder clause.Builder) {
+	builder.AddVar(builder, subquery.DB)
+}

--- a/internal/database/exclause/union.go
+++ b/internal/database/exclause/union.go
@@ -1,0 +1,63 @@
+package exclause
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Union is union clause
+type Union struct {
+	Statements []clause.Expression
+}
+
+// Name union clause name
+func (union Union) Name() string {
+	return "UNION"
+}
+
+// Build build union clause
+func (union Union) Build(builder clause.Builder) {
+	for index, statement := range union.Statements {
+		if index != 0 {
+			builder.WriteString(" UNION ")
+		}
+		statement.Build(builder)
+	}
+}
+
+// MergeClause merge Union clauses
+func (union Union) MergeClause(mergeClause *clause.Clause) {
+	if u, ok := mergeClause.Expression.(Union); ok {
+		statements := make([]clause.Expression, len(u.Statements)+len(union.Statements))
+		copy(statements, u.Statements)
+		copy(statements[len(u.Statements):], union.Statements)
+		union.Statements = statements
+	}
+
+	mergeClause.Expression = union
+}
+
+// NewUnion is easy to create new Union
+//
+//	// examples
+//	// SELECT * FROM `general_users` UNION SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewUnion("SELECT * FROM `admin_users`")).Scan(&users)
+//
+//	// SELECT * FROM `general_users` UNION SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewUnion(db.Table("admin_users"))).Scan(&users)
+//
+//	// SELECT * FROM `general_users` UNION ALL SELECT * FROM `admin_users`
+//	db.Table("general_users").Clauses(exclause.NewUnion("ALL ?", db.Table("admin_users"))).Scan(&users)
+func NewUnion(query interface{}, args ...interface{}) Union {
+	switch v := query.(type) {
+	case *gorm.DB:
+		return Union{
+			Statements: []clause.Expression{Subquery{DB: v}},
+		}
+	case string:
+		return Union{
+			Statements: []clause.Expression{clause.Expr{SQL: v, Vars: args}},
+		}
+	}
+	return Union{}
+}

--- a/internal/database/exclause/union.go
+++ b/internal/database/exclause/union.go
@@ -19,7 +19,9 @@ func (union Union) Name() string {
 func (union Union) Build(builder clause.Builder) {
 	for index, statement := range union.Statements {
 		if index != 0 {
-			builder.WriteString(" UNION ")
+			if _, err := builder.WriteString(" UNION "); err != nil {
+				panic(err)
+			}
 		}
 		statement.Build(builder)
 	}

--- a/internal/database/exclause/union_test.go
+++ b/internal/database/exclause/union_test.go
@@ -84,7 +84,9 @@ func TestUnion_Query(t *testing.T) {
 				Conn:                      mockDB,
 				SkipInitializeWithVersion: true,
 			}))
-			db.Use(New())
+			if err := db.Use(New()); err != nil {
+				t.Fatalf("an error '%s' was not expected when using the database plugin", err)
+			}
 			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
 			if tt.operation != nil {
 				db = tt.operation(db)

--- a/internal/database/exclause/union_test.go
+++ b/internal/database/exclause/union_test.go
@@ -1,0 +1,162 @@
+package exclause
+
+import (
+	"database/sql/driver"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestUnion_Query(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(db *gorm.DB) *gorm.DB
+		want      string
+		wantArgs  []driver.Value
+	}{
+		{
+			name: "When statement is clause.Expr, then should be used as statement",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Union{
+						Statements: []clause.Expression{
+							clause.Expr{
+								SQL:  "ALL ?",
+								Vars: []interface{}{db.Table("admin_users")},
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` UNION ALL SELECT * FROM `admin_users`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When statement is exclause.Subquery, then should be used as statement",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Union{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("admin_users"),
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` UNION SELECT * FROM `admin_users`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When has multiple UNION, then should be used all UNION clause",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Table("general_users").
+					Clauses(Union{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("admin_users"),
+							},
+						},
+					}).
+					Clauses(Union{
+						Statements: []clause.Expression{
+							Subquery{
+								DB: db.Table("guest_users"),
+							},
+						},
+					}).Scan(nil)
+			},
+			want:     "SELECT * FROM `general_users` UNION SELECT * FROM `admin_users` UNION SELECT * FROM `guest_users`",
+			wantArgs: []driver.Value{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db, _ := gorm.Open(mysql.New(mysql.Config{
+				Conn:                      mockDB,
+				SkipInitializeWithVersion: true,
+			}))
+			db.Use(New())
+			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
+			if tt.operation != nil {
+				db = tt.operation(db)
+			}
+			if db.Error != nil {
+				t.Errorf(db.Error.Error())
+			}
+		})
+	}
+}
+
+func TestNewUnion(t *testing.T) {
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+	db, _ := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      mockDB,
+		SkipInitializeWithVersion: true,
+	}))
+	db = db.Table("users")
+	type args struct {
+		subquery interface{}
+		args     []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want Union
+	}{
+		{
+			name: "When subquery is *gorm.DB, then statement is exclause.Subquery",
+			args: args{
+				subquery: db,
+			},
+			want: Union{
+				Statements: []clause.Expression{
+					Subquery{
+						DB: db,
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is string, then statement is clause.Expr",
+			args: args{
+				subquery: "ALL ?",
+				args:     []interface{}{db.Table("users")},
+			},
+			want: Union{
+				Statements: []clause.Expression{
+					clause.Expr{
+						SQL:  "ALL ?",
+						Vars: []interface{}{db.Table("users")},
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is else, then statement is empty Union",
+			args: args{
+				subquery: 0,
+			},
+			want: Union{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewUnion(tt.args.subquery, tt.args.args...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewUnion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/database/exclause/with.go
+++ b/internal/database/exclause/with.go
@@ -58,28 +58,42 @@ func (with With) Build(builder clause.Builder) {
 func (cte CTE) Build(builder clause.Builder, materialized bool) {
 	builder.WriteQuoted(cte.Name)
 	if len(cte.Columns) > 0 {
-		builder.WriteString(" (")
+		if _, err := builder.WriteString(" ("); err != nil {
+			panic(err)
+		}
 		for index, column := range cte.Columns {
 			if index > 0 {
-				builder.WriteByte(',')
+				if err := builder.WriteByte(','); err != nil {
+					panic(err)
+				}
 			}
 			builder.WriteQuoted(column)
 		}
-		builder.WriteByte(')')
+		if err := builder.WriteByte(')'); err != nil {
+			panic(err)
+		}
 	}
 
-	builder.WriteString(" AS ")
+	if _, err := builder.WriteString(" AS "); err != nil {
+		panic(err)
+	}
 
 	// Latest versions of Postgres default to non-materialized CTEs, so we don't need to
 	// specify it explicitly. Sometimes you want to keep the optimisation fence though, in
 	// which case you can set the Materialized flag to true.
 	if materialized {
-		builder.WriteString("MATERIALIZED ")
+		if _, err := builder.WriteString("MATERIALIZED "); err != nil {
+			panic(err)
+		}
 	}
 
-	builder.WriteByte('(')
+	if err := builder.WriteByte('('); err != nil {
+		panic(err)
+	}
 	cte.Subquery.Build(builder)
-	builder.WriteByte(')')
+	if err := builder.WriteByte(')'); err != nil {
+		panic(err)
+	}
 }
 
 // MergeClause merge With clauses

--- a/internal/database/exclause/with.go
+++ b/internal/database/exclause/with.go
@@ -1,0 +1,133 @@
+package exclause
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// With with clause
+//
+//	// examples
+//	// WITH `cte` AS (SELECT * FROM `users`) SELECT * FROM `cte`
+//	db.Clauses(exclause.With{CTEs: []exclause.CTE{{Name: "cte", Subquery: clause.Expr{SQL: "SELECT * FROM `users`"}}}}).Table("cte").Scan(&users)
+//
+//	// WITH `cte` AS (SELECT * FROM `users`) SELECT * FROM `cte`
+//	db.Clauses(exclause.With{CTEs: []exclause.CTE{{Name: "cte", Subquery: exclause.Subquery{DB: db.Table("users")}}}}).Table("cte").Scan(&users)
+//
+//	// WITH `cte` (`id`,`name`) AS (SELECT * FROM `users`) SELECT * FROM `cte`
+//	db.Clauses(exclause.With{CTEs: []exclause.CTE{{Name: "cte", Columns: []string{"id", "name"}, Subquery: exclause.Subquery{DB: db.Table("users")}}}}).Table("cte").Scan(&users)
+//
+//	// WITH RECURSIVE `cte` AS (SELECT * FROM `users`) SELECT * FROM `cte`
+//	db.Clauses(exclause.With{Recursive: true, CTEs: []exclause.CTE{{Name: "cte", Subquery: exclause.Subquery{DB: db.Table("users")}}}}).Table("cte").Scan(&users)
+type With struct {
+	Recursive    bool
+	Materialized bool
+	CTEs         []CTE
+}
+
+// CTE common table expressions
+type CTE struct {
+	Name     string
+	Columns  []string
+	Subquery clause.Expression
+}
+
+// Name with clause name
+func (with With) Name() string {
+	return "WITH"
+}
+
+// Build build with clause
+func (with With) Build(builder clause.Builder) {
+	if with.Recursive {
+		builder.WriteString("RECURSIVE ")
+	}
+	for index, cte := range with.CTEs {
+		if index > 0 {
+			builder.WriteByte(',')
+		}
+		cte.Build(builder, with.Materialized)
+	}
+}
+
+// Build build CTE
+func (cte CTE) Build(builder clause.Builder, materialized bool) {
+	builder.WriteQuoted(cte.Name)
+	if len(cte.Columns) > 0 {
+		builder.WriteString(" (")
+		for index, column := range cte.Columns {
+			if index > 0 {
+				builder.WriteByte(',')
+			}
+			builder.WriteQuoted(column)
+		}
+		builder.WriteByte(')')
+	}
+
+	builder.WriteString(" AS ")
+
+	// Latest versions of Postgres default to non-materialized CTEs, so we don't need to
+	// specify it explicitly. Sometimes you want to keep the optimisation fence though, in
+	// which case you can set the Materialized flag to true.
+	if materialized {
+		builder.WriteString("MATERIALIZED ")
+	}
+
+	builder.WriteByte('(')
+	cte.Subquery.Build(builder)
+	builder.WriteByte(')')
+}
+
+// MergeClause merge With clauses
+func (with With) MergeClause(clause *clause.Clause) {
+	if w, ok := clause.Expression.(With); ok {
+		if w.Recursive {
+			with.Recursive = true
+		}
+		ctes := make([]CTE, len(w.CTEs)+len(with.CTEs))
+		copy(ctes, w.CTEs)
+		copy(ctes[len(w.CTEs):], with.CTEs)
+		with.CTEs = ctes
+	}
+
+	clause.Expression = with
+}
+
+// NewWith is easy to create new With
+//
+//	// examples
+//	// WITH `cte` AS (SELECT * FROM `users`) SELECT * FROM `cte`
+//	db.Clauses(exclause.NewWith("cte", "SELECT * FROM `users`")).Table("cte").Scan(&users)
+//
+//	// WITH `cte` AS (SELECT * FROM `users` WHERE `name` = 'WinterYukky') SELECT * FROM `cte`
+//	db.Clauses(exclause.NewWith("cte", "SELECT * FROM `users` WHERE `name` = ?", "WinterYukky")).Table("cte").Scan(&users)
+//
+//	// WITH `cte` AS (SELECT * FROM `users` WHERE `name` = 'WinterYukky') SELECT * FROM `cte`
+//	db.Clauses(exclause.NewWith("cte", db.Table("users").Where("`name` = ?", "WinterYukky"))).Table("cte").Scan(&users)
+//
+// If you need more advanced WITH clause, you can see With struct.
+func NewWith(name string, subquery interface{}, materialized bool, args ...interface{}) With {
+	switch v := subquery.(type) {
+	case *gorm.DB:
+		return With{
+			CTEs: []CTE{
+				{
+					Name:     name,
+					Subquery: Subquery{DB: v},
+				},
+			},
+			Materialized: materialized,
+		}
+	case string:
+		return With{
+			CTEs: []CTE{
+				{
+					Name:     name,
+					Subquery: clause.Expr{SQL: v, Vars: args},
+				},
+			},
+			Materialized: materialized,
+		}
+	}
+	return With{}
+}

--- a/internal/database/exclause/with.go
+++ b/internal/database/exclause/with.go
@@ -40,11 +40,15 @@ func (with With) Name() string {
 // Build build with clause
 func (with With) Build(builder clause.Builder) {
 	if with.Recursive {
-		builder.WriteString("RECURSIVE ")
+		if _, err := builder.WriteString("RECURSIVE "); err != nil {
+			panic(err)
+		}
 	}
 	for index, cte := range with.CTEs {
 		if index > 0 {
-			builder.WriteByte(',')
+			if err := builder.WriteByte(','); err != nil {
+				panic(err)
+			}
 		}
 		cte.Build(builder, with.Materialized)
 	}

--- a/internal/database/exclause/with_test.go
+++ b/internal/database/exclause/with_test.go
@@ -74,7 +74,9 @@ func TestWith_Query(t *testing.T) {
 				Conn:                      mockDB,
 				SkipInitializeWithVersion: true,
 			}))
-			db.Use(New())
+			if err := db.Use(New()); err != nil {
+				t.Fatalf("an error '%s' was not expected when using the database plugin", err)
+			}
 			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
 			if tt.operation != nil {
 				db = tt.operation(db)

--- a/internal/database/exclause/with_test.go
+++ b/internal/database/exclause/with_test.go
@@ -1,0 +1,163 @@
+package exclause
+
+import (
+	"database/sql/driver"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestWith_Query(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(db *gorm.DB) *gorm.DB
+		want      string
+		wantArgs  []driver.Value
+	}{
+		{
+			name: "When Subquery is clause.Expr, then should be used as subquery",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Clauses(With{CTEs: []CTE{{Name: "cte", Subquery: clause.Expr{SQL: "SELECT * FROM `users` WHERE `name` = ?", Vars: []interface{}{"WinterYukky"}}}}}).Table("cte").Scan(nil)
+			},
+			want:     "WITH `cte` AS (SELECT * FROM `users` WHERE `name` = ?) SELECT * FROM `cte`",
+			wantArgs: []driver.Value{"WinterYukky"},
+		},
+		{
+			name: "When Subquery is exclause.Subquery, then should be used as subquery",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Clauses(With{CTEs: []CTE{{Name: "cte", Subquery: Subquery{DB: db.Table("users").Where("`name` = ?", "WinterYukky")}}}}).Table("cte").Scan(nil)
+			},
+			want:     "WITH `cte` AS (SELECT * FROM `users` WHERE `name` = ?) SELECT * FROM `cte`",
+			wantArgs: []driver.Value{"WinterYukky"},
+		},
+		{
+			name: "When has specific fields, then should be used with columns specified",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Clauses(With{CTEs: []CTE{{Name: "cte", Columns: []string{"id", "name"}, Subquery: Subquery{DB: db.Table("users")}}}}).Table("cte").Scan(nil)
+			},
+			want:     "WITH `cte` (`id`,`name`) AS (SELECT * FROM `users`) SELECT * FROM `cte`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When contains recursive even once, then should be used RECURSIVE keyword",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.
+					Clauses(With{Recursive: true, CTEs: []CTE{{Name: "cte1", Subquery: Subquery{DB: db.Table("users")}}}}).
+					Clauses(With{Recursive: false, CTEs: []CTE{{Name: "cte2", Subquery: Subquery{DB: db.Table("users")}}}}).
+					Table("cte").Scan(nil)
+			},
+			want:     "WITH RECURSIVE `cte1` AS (SELECT * FROM `users`),`cte2` AS (SELECT * FROM `users`) SELECT * FROM `cte`",
+			wantArgs: []driver.Value{},
+		},
+		{
+			name: "When Materialized is true, then the CTE should be materialized",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Clauses(With{Materialized: true, CTEs: []CTE{{Name: "cte", Subquery: clause.Expr{SQL: "SELECT * FROM `users` WHERE `name` = ?", Vars: []interface{}{"WinterYukky"}}}}}).Table("cte").Scan(nil)
+			},
+			want:     "WITH `cte` AS MATERIALIZED (SELECT * FROM `users` WHERE `name` = ?) SELECT * FROM `cte`",
+			wantArgs: []driver.Value{"WinterYukky"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db, _ := gorm.Open(mysql.New(mysql.Config{
+				Conn:                      mockDB,
+				SkipInitializeWithVersion: true,
+			}))
+			db.Use(New())
+			mock.ExpectQuery(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnRows(sqlmock.NewRows([]string{}))
+			if tt.operation != nil {
+				db = tt.operation(db)
+			}
+			if db.Error != nil {
+				t.Errorf(db.Error.Error())
+			}
+		})
+	}
+}
+
+func TestNewWith(t *testing.T) {
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+	db, _ := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      mockDB,
+		SkipInitializeWithVersion: true,
+	}))
+	db = db.Table("users")
+	type args struct {
+		name         string
+		subquery     interface{}
+		materialized bool
+		args         []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want With
+	}{
+		{
+			name: "When subquery is *gorm.DB, then CTE's Subquery is exclause.Subquery",
+			args: args{
+				name:     "cte",
+				subquery: db,
+			},
+			want: With{
+				Recursive: false,
+				CTEs: []CTE{
+					{
+						Name:     "cte",
+						Subquery: Subquery{DB: db},
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is string, then CTE's Subquery is clause.Expr",
+			args: args{
+				name:     "cte",
+				subquery: "SELECT * FROM `users` WHERE `name` = ?",
+				args:     []interface{}{"WinterYukky"},
+			},
+			want: With{
+				Recursive: false,
+				CTEs: []CTE{
+					{
+						Name: "cte",
+						Subquery: clause.Expr{
+							SQL:  "SELECT * FROM `users` WHERE `name` = ?",
+							Vars: []interface{}{"WinterYukky"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "When subquery is else, then CTE's Subquery is empty With",
+			args: args{
+				name:     "cte",
+				subquery: 0,
+			},
+			want: With{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewWith(tt.args.name, tt.args.subquery, tt.args.materialized, tt.args.args...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewWith() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/database/gen/gen.go
+++ b/internal/database/gen/gen.go
@@ -49,8 +49,8 @@ func BuildGenerator(db *gorm.DB) *gen.Generator {
 		"torrent_files",
 		infoHashType,
 		infoHashReadOnly,
-		gen.FieldType("size", "uint64"),
-		gen.FieldType("index", "uint32"),
+		gen.FieldType("size", "uint"),
+		gen.FieldType("index", "uint"),
 		gen.FieldGORMTag("index", func(tag field.GormTag) field.GormTag {
 			tag.Set("<-", "create")
 			return tag
@@ -190,7 +190,7 @@ func BuildGenerator(db *gorm.DB) *gen.Generator {
 			tag.Set("<-", "false")
 			return tag
 		}),
-		gen.FieldType("size", "uint64"),
+		gen.FieldType("size", "uint"),
 		gen.FieldIgnore("tsv"),
 		createdAtReadOnly,
 	)
@@ -364,6 +364,8 @@ func BuildGenerator(db *gorm.DB) *gen.Generator {
 				gen.FieldType("content_type", "NullContentType"),
 				gen.FieldType("seeders", "NullUint"),
 				gen.FieldType("leechers", "NullUint"),
+				gen.FieldType("size", "uint"),
+				gen.FieldType("files_count", "NullUint"),
 			},
 			torrentContentBaseOptions...,
 		)...,

--- a/internal/database/gorm.go
+++ b/internal/database/gorm.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"github.com/bitmagnet-io/bitmagnet/internal/boilerplate/lazy"
+	"github.com/bitmagnet-io/bitmagnet/internal/database/exclause"
 	"github.com/bitmagnet-io/bitmagnet/internal/database/logger"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
@@ -38,12 +39,15 @@ func New(p Params) Result {
 					ZapLogger: p.Logger,
 					Config: logger.Config{
 						LogLevel:      gormlogger.Info,
-						SlowThreshold: time.Second * 3,
+						SlowThreshold: time.Second * 20,
 					},
 				}).GormLogger,
 			})
 			if dbErr != nil {
 				return nil, dbErr
+			}
+			if pluginErr := gDb.Use(exclause.New()); pluginErr != nil {
+				return nil, pluginErr
 			}
 			return gDb, nil
 		}),

--- a/internal/database/logger/logger.go
+++ b/internal/database/logger/logger.go
@@ -67,7 +67,7 @@ func (l *customLogger) Trace(_ context.Context, begin time.Time, fc func() (stri
 	}
 	elapsed := time.Since(begin)
 	switch {
-	case err != nil && l.logLevel >= gormlogger.Error && !errors.Is(err, gormlogger.ErrRecordNotFound):
+	case err != nil && l.logLevel >= gormlogger.Error && !errors.Is(err, gormlogger.ErrRecordNotFound) && !errors.Is(err, context.Canceled):
 		sql, rows := fc()
 		l.zap.Errorw("gorm trace", "location", utils.FileWithLineNum(), "error", err, "elapsed", float64(elapsed.Nanoseconds())/1e6, "sql", sql, "rows", rows)
 	case elapsed > l.slowThreshold && l.slowThreshold != 0 && l.logLevel >= gormlogger.Warn:

--- a/internal/database/query/criteria.go
+++ b/internal/database/query/criteria.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bitmagnet-io/bitmagnet/internal/maps"
 	"github.com/bitmagnet-io/bitmagnet/internal/regex"
 	"gorm.io/gen/field"
+	"gorm.io/gorm"
 	"strings"
 )
 
@@ -19,9 +20,9 @@ func Where(conditions ...Criteria) Option {
 			rawCriteria = append(rawCriteria, rc)
 			joins.SetEntries(rc.Joins.Entries()...)
 		}
-		b = b.Scope(func(dao SubQuery) error {
+		b = b.Scope(func(db *gorm.DB) error {
 			for _, raw := range rawCriteria {
-				dao.UnderlyingDB().Where(raw.Query, raw.Args...)
+				db.Where(raw.Query, raw.Args...)
 			}
 			return nil
 		})

--- a/internal/database/query/options.go
+++ b/internal/database/query/options.go
@@ -125,13 +125,6 @@ func OrderByQueryStringRank() Option {
 	}
 }
 
-//func OrderByColumn(field string, desc bool) Option {
-//	return OrderBy(clause.OrderByColumn{
-//		Column: clause.Column{Name: field},
-//		Desc:   desc,
-//	})
-//}
-
 func WithFacet(facets ...Facet) Option {
 	return func(ctx OptionBuilder) (OptionBuilder, error) {
 		return ctx.Facet(facets...), nil

--- a/internal/database/query/options.go
+++ b/internal/database/query/options.go
@@ -105,7 +105,7 @@ func Offset(n uint) Option {
 	}
 }
 
-func OrderBy(columns ...clause.OrderByColumn) Option {
+func OrderBy(columns ...OrderByColumn) Option {
 	return func(ctx OptionBuilder) (OptionBuilder, error) {
 		return ctx.OrderBy(columns...), nil
 	}
@@ -115,20 +115,22 @@ const QueryStringRankField = "query_string_rank"
 
 func OrderByQueryStringRank() Option {
 	return func(ctx OptionBuilder) (OptionBuilder, error) {
-		return ctx.OrderBy(clause.OrderByColumn{
-			Column:  clause.Column{Name: QueryStringRankField},
-			Desc:    true,
-			Reorder: true,
+		return ctx.OrderBy(OrderByColumn{
+			OrderByColumn: clause.OrderByColumn{
+				Column:  clause.Column{Name: QueryStringRankField},
+				Desc:    true,
+				Reorder: true,
+			},
 		}), nil
 	}
 }
 
-func OrderByColumn(field string, desc bool) Option {
-	return OrderBy(clause.OrderByColumn{
-		Column: clause.Column{Name: field},
-		Desc:   desc,
-	})
-}
+//func OrderByColumn(field string, desc bool) Option {
+//	return OrderBy(clause.OrderByColumn{
+//		Column: clause.Column{Name: field},
+//		Desc:   desc,
+//	})
+//}
 
 func WithFacet(facets ...Facet) Option {
 	return func(ctx OptionBuilder) (OptionBuilder, error) {

--- a/internal/database/query/query.go
+++ b/internal/database/query/query.go
@@ -82,7 +82,6 @@ type genericQuery[T interface{}] struct {
 	daoQ    *dao.Query
 	factory SubQueryFactory
 	builder OptionBuilder
-	exists  bool
 	mtx     sync.Mutex
 	errs    []error
 	result  GenericResult[T]

--- a/internal/database/search/facet_torrent_content_genre.go
+++ b/internal/database/search/facet_torrent_content_genre.go
@@ -15,6 +15,7 @@ func TorrentContentGenreFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasLabel("Genre"),
 				query.FacetUsesLogic(model.FacetLogicAnd),
 				query.FacetHasAggregationOption(query.RequireJoin(model.TableNameTorrentContent)),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 		collectionType: "genre",

--- a/internal/database/search/facet_torrent_content_language.go
+++ b/internal/database/search/facet_torrent_content_language.go
@@ -17,6 +17,7 @@ func TorrentContentLanguageFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasKey(LanguageFacetKey),
 				query.FacetHasLabel("Language"),
 				query.FacetUsesLogic(model.FacetLogicOr),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 	}

--- a/internal/database/search/facet_torrent_content_type.go
+++ b/internal/database/search/facet_torrent_content_type.go
@@ -17,6 +17,7 @@ func TorrentContentTypeFacet(options ...query.FacetOption) query.Facet {
 					query.FacetHasKey(TorrentContentTypeFacetKey),
 					query.FacetHasLabel("Content Type"),
 					query.FacetUsesOrLogic(),
+					query.FacetTriggersCte(),
 				}, options...)...,
 			),
 			field: func(q *dao.Query) field.Field {

--- a/internal/database/search/facet_torrent_content_video_3d.go
+++ b/internal/database/search/facet_torrent_content_video_3d.go
@@ -20,6 +20,7 @@ func Video3dFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasKey(Video3dFacetKey),
 				query.FacetHasLabel("Video 3D"),
 				query.FacetUsesOrLogic(),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 		field: video3dField,

--- a/internal/database/search/facet_torrent_content_video_codec.go
+++ b/internal/database/search/facet_torrent_content_video_codec.go
@@ -16,6 +16,7 @@ func VideoCodecFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasKey(VideoCodecFacetKey),
 				query.FacetHasLabel("Video Codec"),
 				query.FacetUsesOrLogic(),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 		field: func(q *dao.Query) field.Field {

--- a/internal/database/search/facet_torrent_content_video_modifier.go
+++ b/internal/database/search/facet_torrent_content_video_modifier.go
@@ -16,6 +16,7 @@ func VideoModifierFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasKey(VideoModifierFacetKey),
 				query.FacetHasLabel("Video Modifier"),
 				query.FacetUsesOrLogic(),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 		field: func(q *dao.Query) field.Field {

--- a/internal/database/search/facet_torrent_content_video_resolution.go
+++ b/internal/database/search/facet_torrent_content_video_resolution.go
@@ -20,6 +20,7 @@ func VideoResolutionFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasKey(VideoResolutionFacetKey),
 				query.FacetHasLabel("Video Resolution"),
 				query.FacetUsesOrLogic(),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 		field: videoResolutionField,

--- a/internal/database/search/facet_torrent_content_video_source.go
+++ b/internal/database/search/facet_torrent_content_video_source.go
@@ -16,6 +16,7 @@ func VideoSourceFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasKey(VideoSourceFacetKey),
 				query.FacetHasLabel("Video Source"),
 				query.FacetUsesOrLogic(),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 		field: func(q *dao.Query) field.Field {

--- a/internal/database/search/facet_torrent_file_type.go
+++ b/internal/database/search/facet_torrent_file_type.go
@@ -16,6 +16,7 @@ func TorrentFileTypeFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasLabel("File Type"),
 				query.FacetUsesOrLogic(),
 				query.FacetHasAggregationOption(query.RequireJoin(model.TableNameTorrentContent)),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 	}

--- a/internal/database/search/facet_torrent_tag.go
+++ b/internal/database/search/facet_torrent_tag.go
@@ -15,6 +15,7 @@ func TorrentTagsFacet(options ...query.FacetOption) query.Facet {
 				query.FacetHasLabel("Torrent Tag"),
 				query.FacetUsesAndLogic(),
 				query.FacetHasAggregationOption(query.RequireJoin(model.TableNameTorrentContent)),
+				query.FacetTriggersCte(),
 			}, options...)...,
 		),
 	}

--- a/internal/database/search/order_torrent_content.go
+++ b/internal/database/search/order_torrent_content.go
@@ -121,8 +121,5 @@ func (fob TorrentContentFullOrderBy) Clauses() []query.OrderByColumn {
 }
 
 func (fob TorrentContentFullOrderBy) Option() query.Option {
-	return query.Options(
-		query.RequireJoin(model.TableNameTorrent),
-		query.OrderBy(fob.Clauses()...),
-	)
+	return query.OrderBy(fob.Clauses()...)
 }

--- a/internal/database/search/search_torrent_content.go
+++ b/internal/database/search/search_torrent_content.go
@@ -40,24 +40,30 @@ func TorrentContentDefaultOption() query.Option {
 		TorrentContentDefaultHydrate(),
 		TorrentContentCoreJoins(),
 		query.OrderBy(
-			clause.OrderByColumn{
-				Column: clause.Column{
-					Table: clause.CurrentTable,
-					Name:  "published_at",
+			query.OrderByColumn{
+				OrderByColumn: clause.OrderByColumn{
+					Column: clause.Column{
+						Table: clause.CurrentTable,
+						Name:  "published_at",
+					},
+					Desc: true,
 				},
-				Desc: true,
 			},
-			clause.OrderByColumn{
-				Column: clause.Column{
-					Table: clause.CurrentTable,
-					Name:  "updated_at",
+			query.OrderByColumn{
+				OrderByColumn: clause.OrderByColumn{
+					Column: clause.Column{
+						Table: clause.CurrentTable,
+						Name:  "updated_at",
+					},
+					Desc: true,
 				},
-				Desc: true,
 			},
-			clause.OrderByColumn{
-				Column: clause.Column{
-					Table: clause.CurrentTable,
-					Name:  "info_hash",
+			query.OrderByColumn{
+				OrderByColumn: clause.OrderByColumn{
+					Column: clause.Column{
+						Table: clause.CurrentTable,
+						Name:  "info_hash",
+					},
 				},
 			},
 		),

--- a/internal/database/search/search_torrents.go
+++ b/internal/database/search/search_torrents.go
@@ -120,7 +120,7 @@ func (s search) TorrentSuggestTags(ctx context.Context, q SuggestTagsQuery, opti
 					SQL: "torrent_tags.name AS name",
 				},
 				clause.Expr{
-					SQL: "count(torrent_tags.*) AS count",
+					SQL: "count(torrent_tags.*) AS total_count",
 				},
 			),
 			query.Where(criteria...),
@@ -129,8 +129,22 @@ func (s search) TorrentSuggestTags(ctx context.Context, q SuggestTagsQuery, opti
 					Name: "torrent_tags.name",
 				},
 			),
-			query.OrderByColumn("count", true),
-			query.OrderByColumn("name", false),
+			query.OrderBy(
+				query.OrderByColumn{
+					OrderByColumn: clause.OrderByColumn{
+						Column: clause.Column{
+							Alias: "total_count",
+						},
+					},
+				},
+				query.OrderByColumn{
+					OrderByColumn: clause.OrderByColumn{
+						Column: clause.Column{
+							Alias: "name",
+						},
+					},
+				},
+			),
 			query.Limit(10),
 		}, options...)...),
 		model.TableNameTorrentTag,

--- a/internal/dhtcrawler/persist.go
+++ b/internal/dhtcrawler/persist.go
@@ -155,9 +155,9 @@ func createTorrentModel(
 		}
 		files = append(files, model.TorrentFile{
 			InfoHash: hash,
-			Index:    uint32(i),
+			Index:    uint(i),
 			Path:     file.DisplayPath(&info),
-			Size:     uint64(file.Length),
+			Size:     uint(file.Length),
 		})
 	}
 	var pieces model.TorrentPieces
@@ -171,7 +171,7 @@ func createTorrentModel(
 	return model.Torrent{
 		InfoHash:    hash,
 		Name:        name,
-		Size:        uint64(info.TotalLength()),
+		Size:        uint(info.TotalLength()),
 		Private:     private,
 		Pieces:      pieces,
 		Files:       files,

--- a/internal/gql/gql.gen.go
+++ b/internal/gql/gql.gen.go
@@ -5515,9 +5515,9 @@ func (ec *executionContext) _Torrent_size(ctx context.Context, field graphql.Col
 		}
 		return graphql.Null
 	}
-	res := resTmp.(uint64)
+	res := resTmp.(uint)
 	fc.Result = res
-	return ec.marshalNInt2uint64(ctx, field.Selections, res)
+	return ec.marshalNInt2uint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Torrent_size(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8050,9 +8050,9 @@ func (ec *executionContext) _TorrentFile_index(ctx context.Context, field graphq
 		}
 		return graphql.Null
 	}
-	res := resTmp.(uint32)
+	res := resTmp.(uint)
 	fc.Result = res
-	return ec.marshalNInt2uint32(ctx, field.Selections, res)
+	return ec.marshalNInt2uint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TorrentFile_index(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8220,9 +8220,9 @@ func (ec *executionContext) _TorrentFile_size(ctx context.Context, field graphql
 		}
 		return graphql.Null
 	}
-	res := resTmp.(uint64)
+	res := resTmp.(uint)
 	fc.Result = res
-	return ec.marshalNInt2uint64(ctx, field.Selections, res)
+	return ec.marshalNInt2uint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TorrentFile_size(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -14704,36 +14704,6 @@ func (ec *executionContext) unmarshalNInt2uint(ctx context.Context, v interface{
 
 func (ec *executionContext) marshalNInt2uint(ctx context.Context, sel ast.SelectionSet, v uint) graphql.Marshaler {
 	res := graphql.MarshalUint(v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
-func (ec *executionContext) unmarshalNInt2uint32(ctx context.Context, v interface{}) (uint32, error) {
-	res, err := graphql.UnmarshalUint32(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNInt2uint32(ctx context.Context, sel ast.SelectionSet, v uint32) graphql.Marshaler {
-	res := graphql.MarshalUint32(v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
-func (ec *executionContext) unmarshalNInt2uint64(ctx context.Context, v interface{}) (uint64, error) {
-	res, err := graphql.UnmarshalUint64(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNInt2uint64(ctx context.Context, sel ast.SelectionSet, v uint64) graphql.Marshaler {
-	res := graphql.MarshalUint64(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -21,7 +21,7 @@ type Item struct {
 	Source          string
 	InfoHash        protocol.ID
 	Name            string
-	Size            uint64
+	Size            uint
 	Private         bool
 	ContentType     model.NullContentType
 	ContentSource   model.NullString

--- a/internal/model/torrent_contents.gen.go
+++ b/internal/model/torrent_contents.gen.go
@@ -34,6 +34,8 @@ type TorrentContent struct {
 	Seeders         NullUint            `gorm:"column:seeders" json:"seeders"`
 	Leechers        NullUint            `gorm:"column:leechers" json:"leechers"`
 	PublishedAt     time.Time           `gorm:"column:published_at;not null;default:1999-01-01 00:00:00+00" json:"publishedAt"`
+	Size            uint                `gorm:"column:size;not null" json:"size"`
+	FilesCount      NullUint            `gorm:"column:files_count" json:"filesCount"`
 	Torrent         Torrent             `gorm:"foreignKey:InfoHash;references:InfoHash" json:"torrent"`
 	Content         Content             `gorm:"foreignKey:ContentType,ContentSource,ContentID;references:Type,Source,ID" json:"content"`
 }

--- a/internal/model/torrent_contents.go
+++ b/internal/model/torrent_contents.go
@@ -3,23 +3,8 @@ package model
 import (
 	"fmt"
 	"github.com/bitmagnet-io/bitmagnet/internal/database/fts"
-	"gorm.io/gorm"
 	"strings"
 )
-
-func (tc *TorrentContent) AfterFind(*gorm.DB) error {
-	// the following is a mitigation following the v0.9.0 release where seeders, leechers and size are sourced from the torrent_contents table
-	// because these fields won't be available until after reprocessing, calculate the values here if they are missing;
-	// it should be removed at some point
-	if !tc.Seeders.Valid && !tc.Leechers.Valid {
-		tc.Seeders = tc.Torrent.Seeders()
-		tc.Leechers = tc.Torrent.Leechers()
-	}
-	if tc.Size == 0 {
-		tc.Size = tc.Torrent.Size
-	}
-	return nil
-}
 
 func (tc TorrentContent) InferID() string {
 	parts := make([]string, 4)

--- a/internal/model/torrent_files.gen.go
+++ b/internal/model/torrent_files.gen.go
@@ -15,10 +15,10 @@ const TableNameTorrentFile = "torrent_files"
 // TorrentFile mapped from table <torrent_files>
 type TorrentFile struct {
 	InfoHash  protocol.ID `gorm:"column:info_hash;primaryKey;<-:create" json:"infoHash"`
-	Index     uint32      `gorm:"column:index;not null;<-:create" json:"index"`
+	Index     uint        `gorm:"column:index;not null;<-:create" json:"index"`
 	Path      string      `gorm:"column:path;primaryKey;<-:create" json:"path"`
 	Extension NullString  `gorm:"column:extension;<-:false" json:"extension"`
-	Size      uint64      `gorm:"column:size;not null" json:"size"`
+	Size      uint        `gorm:"column:size;not null" json:"size"`
 	CreatedAt time.Time   `gorm:"column:created_at;not null;<-:create" json:"createdAt"`
 	UpdatedAt time.Time   `gorm:"column:updated_at;not null" json:"updatedAt"`
 }

--- a/internal/model/torrents.gen.go
+++ b/internal/model/torrents.gen.go
@@ -16,7 +16,7 @@ const TableNameTorrent = "torrents"
 type Torrent struct {
 	InfoHash    protocol.ID             `gorm:"column:info_hash;primaryKey;<-:create" json:"infoHash"`
 	Name        string                  `gorm:"column:name;not null" json:"name"`
-	Size        uint64                  `gorm:"column:size;not null" json:"size"`
+	Size        uint                    `gorm:"column:size;not null" json:"size"`
 	Private     bool                    `gorm:"column:private;not null" json:"private"`
 	CreatedAt   time.Time               `gorm:"column:created_at;not null;<-:create" json:"createdAt"`
 	UpdatedAt   time.Time               `gorm:"column:updated_at;not null" json:"updatedAt"`

--- a/internal/model/torrents.go
+++ b/internal/model/torrents.go
@@ -73,7 +73,7 @@ func (t Torrent) PublishedAt() time.Time {
 func (t Torrent) MagnetUri() string {
 	return "magnet:?xt=urn:btih:" + t.InfoHash.String() +
 		"&dn=" + url.QueryEscape(t.Name) +
-		"&xl=" + strconv.FormatUint(t.Size, 10)
+		"&xl=" + strconv.FormatUint(uint64(t.Size), 10)
 }
 
 // HasFilesInfo returns true if we know about the files in this torrent.

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -156,6 +156,12 @@ func (c processor) Process(ctx context.Context, params MessageParams) error {
 }
 
 func newTorrentContent(t model.Torrent, c classification.Result) model.TorrentContent {
+	var filesCount model.NullUint
+	if t.FilesCount.Valid {
+		filesCount = t.FilesCount
+	} else if t.FilesStatus == model.FilesStatusSingle {
+		filesCount = model.NewNullUint(1)
+	}
 	tc := model.TorrentContent{
 		Torrent:         t,
 		InfoHash:        t.InfoHash,
@@ -168,6 +174,8 @@ func newTorrentContent(t model.Torrent, c classification.Result) model.TorrentCo
 		Video3d:         c.Video3d,
 		VideoModifier:   c.VideoModifier,
 		ReleaseGroup:    c.ReleaseGroup,
+		Size:            t.Size,
+		FilesCount:      filesCount,
 		Seeders:         t.Seeders(),
 		Leechers:        t.Leechers(),
 		PublishedAt:     t.PublishedAt(),

--- a/internal/torznab/adapter/search.go
+++ b/internal/torznab/adapter/search.go
@@ -213,7 +213,7 @@ func (a adapter) transformSearchResult(req torznab.SearchRequest, res search.Tor
 			},
 			{
 				AttrName:  torznab.AttrSize,
-				AttrValue: strconv.FormatUint(item.Torrent.Size, 10),
+				AttrValue: strconv.FormatUint(uint64(item.Torrent.Size), 10),
 			},
 			{
 				AttrName:  torznab.AttrPublishDate,
@@ -291,7 +291,7 @@ func (a adapter) transformSearchResult(req torznab.SearchRequest, res search.Tor
 			Enclosure: torznab.SearchResultItemEnclosure{
 				URL:    item.Torrent.MagnetUri(),
 				Type:   "application/x-bittorrent;x-scheme-handler/magnet",
-				Length: strconv.FormatUint(item.Torrent.Size, 10),
+				Length: strconv.FormatUint(uint64(item.Torrent.Size), 10),
 			},
 			TorznabAttrs: attrs,
 		})

--- a/internal/torznab/result.go
+++ b/internal/torznab/result.go
@@ -110,7 +110,7 @@ type SearchResultItem struct {
 	PubDate      RssDate                       `xml:"pubDate,omitempty"`
 	Category     string                        `xml:"category,omitempty"`
 	Link         string                        `xml:"link,omitempty"`
-	Size         uint64                        `xml:"size"`
+	Size         uint                          `xml:"size"`
 	Description  string                        `xml:"description,omitempty"`
 	Comments     string                        `xml:"comments,omitempty"`
 	Enclosure    SearchResultItemEnclosure     `xml:"enclosure"`

--- a/migrations/00018_indexes.sql
+++ b/migrations/00018_indexes.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+
+alter table torrent_contents add column size bigint not null default 0;
+alter table torrent_contents add column files_count integer;
+create index on torrent_contents(size);
+create index on torrent_contents(coalesce(files_count, 0));
+
+create index torrent_contents_seeders_coalesce_idx on torrent_contents (coalesce(seeders, -1));
+create index torrent_contents_leechers_coalesce_idx on torrent_contents (coalesce(leechers, -1));
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+drop index torrent_contents_seeders_coalesce_idx;
+drop index torrent_contents_leechers_coalesce_idx;
+
+-- +goose StatementEnd

--- a/migrations/00018_ordering_fields.sql
+++ b/migrations/00018_ordering_fields.sql
@@ -14,6 +14,8 @@ create index torrent_contents_leechers_coalesce_idx on torrent_contents (coalesc
 -- +goose Down
 -- +goose StatementBegin
 
+alter table torrent_contents drop column size;
+alter table torrent_contents drop column files_count;
 drop index torrent_contents_seeders_coalesce_idx;
 drop index torrent_contents_leechers_coalesce_idx;
 


### PR DESCRIPTION
For querying search result items, we try 2 strategies:
- the default strategy is always tried, and is usually the most performant
- for certain searches where items are filtered to a small number of results, and ordered with a limit, the default strategy can be very slow, so we try a CTE strategy, with order and limit on a materialized view of the complete results, and we put it in a race with the default strategy