### PR TITLE
Increase rate limit burst when using default TMDB API key

### DIFF
--- a/internal/tmdb/requester_lazy.go
+++ b/internal/tmdb/requester_lazy.go
@@ -39,7 +39,7 @@ func newRequester(ctx context.Context, config Config, logger *zap.SugaredLogger)
 	if config.ApiKey == defaultTmdbApiKey {
 		logger.Warnln("you are using the default TMDB api key; TMDB requests will be limited to 1 per second; to remove this warning please configure a personal TMDB api key")
 		config.RateLimit = time.Second
-		config.RateLimitBurst = 1
+		config.RateLimitBurst = 8
 	}
 	r := requesterLogger{
 		requester: requesterFailFast{


### PR DESCRIPTION
Allow rate limit "burst" for TMDB API when using the default API key, allowing the limit to average to 1 second with a lot less blocking.