### PR TITLE
Switch sort order for Torznab from Relevance to Published

### DIFF
--- a/internal/database/query/options.go
+++ b/internal/database/query/options.go
@@ -125,6 +125,18 @@ func OrderByQueryStringRank() Option {
 	}
 }
 
+func OrderByPublishedAt() Option {
+	return func(ctx OptionBuilder) (OptionBuilder, error) {
+		return ctx.OrderBy(OrderByColumn{
+			OrderByColumn: clause.OrderByColumn{
+				Column:  clause.Column{Name: "published_at"},
+				Desc:    true,
+				Reorder: true,
+			},
+		}), nil
+	}
+}
+
 func WithFacet(facets ...Facet) Option {
 	return func(ctx OptionBuilder) (OptionBuilder, error) {
 		return ctx.Facet(facets...), nil

--- a/internal/torznab/adapter/search.go
+++ b/internal/torznab/adapter/search.go
@@ -58,7 +58,7 @@ func (a adapter) searchRequestOptions(r torznab.SearchRequest) ([]query.Option, 
 		}
 	}
 	if r.Query != "" {
-		options = append(options, query.QueryString(r.Query), query.OrderByQueryStringRank())
+		options = append(options, query.QueryString(r.Query), query.OrderByPublishedAt())
 	}
 	var catsCriteria []query.Criteria
 	for _, cat := range r.Cats {


### PR DESCRIPTION
This PR is to switch the Torznab sort order from 'OrderByQueryStringRank' (Relevance) to 'OrderByPublishedAt' (Published) when defining a search criteria.

**The Problem**
- Relevance sort order does not always give you the latest magnets, it will generally be a mix, i'm not sure how Relevance works but the published date for the magnets is not consistent.
- Due to the mix of published date when Relevance is used you quite frequently can end up with magnets with no seeders.

**The Solution**
Switching the sort order to Published date means you get the very latest magnets as they are discovered, which means newer titles tend to be at the beginning of the search list. Due to the list being sorted by Published date it also means there is a **much** higher chance of at least 1 seed and thus a higher chance of completion.

Hands up here, I have **no** experience developing in Go, so this implementation maybe done much better in another way, but for now at least it does do what I intended.

EDIT - Due to my lack of knowledge of Go I have switched this to a Draft PR as it no doubt needs further work before being considered for inclusion in main.