### PR TITLE
classifier - plugins for sourcing flag lists

### DIFF
--- a/internal/classifier/flag_plugins.go
+++ b/internal/classifier/flag_plugins.go
@@ -1,0 +1,136 @@
+package classifier
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+type pluginContentList []struct {
+	SeriesId *interface{} `json:"seriesId,omitempty"`
+	TmdbId   *int         `json:"tmdbId,omitempty"`
+	Id       *interface{} `json:"Id,omitempty"`
+}
+
+func (l pluginContentList) TmdbIds(p pluginSource) []string {
+	var list []string
+	for _, item := range l {
+		if item.TmdbId != nil && *item.TmdbId > 0 {
+			list = append(list, strconv.Itoa(*item.TmdbId))
+		} else if item.TmdbId == nil && (item.SeriesId != nil || item.Id != nil) {
+			// there are cases of episodes and series
+			if item.SeriesId == nil {
+				item.SeriesId = item.Id
+			}
+			u, _ := url.Parse(p.Url)
+			var tmdbid struct {
+				TmdbId      int `json:"tmdbId"`
+				ProviderIds struct {
+					Tmdb string `json:"tmdb"`
+				} `json:"ProviderIds"`
+			}
+			req := resty.New().R().SetQueryParam("apikey", *p.ApiKey).SetResult(&tmdbid)
+			switch (*item.SeriesId).(type) {
+			case string:
+				req.Get(fmt.Sprintf("%s://%s/Items/%v?%s", u.Scheme, u.Host, *item.SeriesId, u.RawQuery))
+				list = append(list, tmdbid.ProviderIds.Tmdb)
+			default:
+				req.Get(fmt.Sprintf("%s://%s%s/series/%v", u.Scheme, u.Host, path.Dir(u.Path), *item.SeriesId))
+				if tmdbid.TmdbId > 0 {
+					list = append(list, strconv.Itoa(tmdbid.TmdbId))
+				}
+			}
+		}
+	}
+
+	slices.Sort(list)
+	return slices.Compact(list)
+}
+
+type pluginContentStruct struct {
+	Page    int `json:"page"`
+	Results []struct {
+		Id int `json:"id"`
+	} `json:"results"`
+	TotalPages int `json:"total_pages"`
+}
+
+func (l pluginContentStruct) TmdbIds() []string {
+	var list []string
+	for _, item := range l.Results {
+		list = append(list, strconv.Itoa(item.Id))
+	}
+
+	return list
+}
+
+// a string_list has to be []any not []string
+func (p pluginSource) any(data []string) []any {
+	anydata := make([]any, len(data))
+	for i, v := range data {
+		anydata[i] = v
+	}
+	return anydata
+}
+
+func (p pluginSource) source() ([]string, error) {
+	var r pluginContentList
+	var s pluginContentStruct
+	req := resty.New().R()
+	if p.ApiKey != nil {
+		u, _ := url.Parse(p.Url)
+		parmName := "apikey"
+		switch u.Host {
+		case "api.themoviedb.org":
+			parmName = "api_key"
+		}
+		req = req.SetQueryParam(parmName, *p.ApiKey)
+	}
+	if p.Start != nil {
+		req = req.SetQueryParam(*p.Start, time.Now().Add(time.Duration(*p.Days)*24*time.Hour*-1).Format(time.DateOnly))
+	}
+	if p.End != nil {
+		req = req.SetQueryParam(*p.End, time.Now().Add(time.Duration(*p.Days+1)*24*time.Hour).Format(time.DateOnly))
+	}
+	resp, err := req.Get(p.Url)
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsError() {
+		return nil, fmt.Errorf("%v %v\n%s\n%s\n", resp.StatusCode(), resp.Request.URL, resp.Status(), resp.Body())
+	}
+	if resp.StatusCode() == 404 {
+		return nil, fmt.Errorf("%v %v %v", resp.StatusCode(), resp.Request.URL, resp.Status())
+
+	}
+
+	// try type of response from sonarr / radarr / jellyfin
+	err = json.Unmarshal(resp.Body(), &r)
+	if err == nil {
+		return r.TmdbIds(p), nil
+
+	}
+
+	// try type of response from tmdb
+	err = json.Unmarshal(resp.Body(), &s)
+	if err == nil {
+		list := s.TmdbIds()
+		for s.Page < s.TotalPages {
+			_, err = req.SetQueryParam("page", strconv.Itoa(s.Page+1)).SetResult(&s).Get(p.Url)
+			if err != nil {
+				return list, err
+			}
+			list = append(list, s.TmdbIds()...)
+
+		}
+		return list, nil
+	}
+
+	return nil, err
+}

--- a/internal/classifier/source.go
+++ b/internal/classifier/source.go
@@ -7,6 +7,7 @@ type Source struct {
 	Flags           Flags           `json:"flags"`
 	Keywords        keywordGroups   `json:"keywords"`
 	Extensions      extensionGroups `json:"extensions"`
+	Plugins         pluginGroups    `json:"plugins,omitempty"`
 }
 
 func (s Source) merge(other Source) (Source, error) {
@@ -20,6 +21,7 @@ func (s Source) merge(other Source) (Source, error) {
 		Keywords:        s.Keywords.merge(other.Keywords),
 		Extensions:      s.Extensions.merge(other.Extensions),
 		Workflows:       s.Workflows.merge(other.Workflows),
+		Plugins:         s.Plugins.merge(other.Plugins),
 	}, nil
 }
 
@@ -78,6 +80,30 @@ func (s workflowSources) merge(other workflowSources) workflowSources {
 	}
 	for k, v := range other {
 		result[k] = v
+	}
+	return result
+}
+
+type pluginSource struct {
+	Url    string  `json:"url"`
+	ApiKey *string `json:"apikey,omitempty"`
+	Start  *string `json:"start,omitempy"`
+	End    *string `json:"end,omitempy"`
+	Days   *int    `json:"days,omitempty"`
+}
+
+type pluginGroups []struct {
+	Source pluginSource `json:"source"`
+	Flag   string       `json:"flag"`
+}
+
+func (s pluginGroups) merge(other pluginGroups) pluginGroups {
+	var result pluginGroups
+	for _, v := range s {
+		result = append(result, v)
+	}
+	for _, v := range other {
+		result = append(result, v)
 	}
 	return result
 }

--- a/internal/classifier/source_provider.go
+++ b/internal/classifier/source_provider.go
@@ -1,10 +1,11 @@
 package classifier
 
 import (
+	"os"
+
 	"github.com/adrg/xdg"
 	"github.com/bitmagnet-io/bitmagnet/internal/tmdb"
 	"gopkg.in/yaml.v3"
-	"os"
 )
 
 func newSourceProvider(config Config, tmdbConfig tmdb.Config) sourceProvider {
@@ -42,6 +43,14 @@ func (m mergeSourceProvider) source() (Source, error) {
 			source = merged
 		}
 	}
+	for _, plugin := range source.Plugins {
+		data, err := plugin.Source.source()
+		if err != nil {
+			return source, err
+		}
+		source.Flags[plugin.Flag] = plugin.Source.any(data)
+	}
+
 	return source, nil
 }
 


### PR DESCRIPTION
Enable sourcing of TMDB IDs for use in classifier.   This then enables more dynamic content based rules to be constructed.

Example sourcing:
```
plugins:
  - source: 
      url: http://radarr.home/api/v3/movie
      apikey: secret
    extension: radarr
  - source:
      url: http://sonarr.home/api/v3/series?apikey=secret
    extension: sonarr
  - source:
      url: http://192.168.1.202:8989/api/v3/calendar
      apikey: secret
      start: start
      end: end
      days: 10
    extension: tvsonarrairing
  - source:
      url: https://api.themoviedb.org/3/discover/tv?with_original_language=en&vote_average.gte=7
      apikey: secret
      start: air_date.gte
      end: air_date.lte
      days: 2
    extension: tmdbtvairing

```

Was proposed as an idea in issue #352   Have extended to make more flexible for APIs from sonarr, radarr and TMDB