### PR TITLE
prowlarr / sonarr / radarr useability

### DIFF
--- a/internal/torznab/adapter/search.go
+++ b/internal/torznab/adapter/search.go
@@ -277,6 +277,12 @@ func (a adapter) transformSearchResult(req torznab.SearchRequest, res search.Tor
 				AttrValue: item.ReleaseGroup.String,
 			})
 		}
+		if item.ContentID.Valid {
+			attrs = append(attrs, torznab.SearchResultItemTorznabAttr{
+				AttrName:  torznab.AttrTmdb,
+				AttrValue: item.ContentID.String,
+			})
+		}
 		if imdbId, ok := item.Content.Identifier("imdb"); ok {
 			attrs = append(attrs, torznab.SearchResultItemTorznabAttr{
 				AttrName:  torznab.AttrImdb,

--- a/internal/torznab/adapter/search.go
+++ b/internal/torznab/adapter/search.go
@@ -3,12 +3,13 @@ package adapter
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/bitmagnet-io/bitmagnet/internal/database/query"
 	"github.com/bitmagnet-io/bitmagnet/internal/database/search"
 	"github.com/bitmagnet-io/bitmagnet/internal/model"
 	"github.com/bitmagnet-io/bitmagnet/internal/torznab"
-	"strconv"
-	"strings"
 )
 
 func (a adapter) Search(ctx context.Context, req torznab.SearchRequest) (torznab.SearchResult, error) {
@@ -228,7 +229,7 @@ func (a adapter) transformSearchResult(req torznab.SearchRequest, res search.Tor
 		}
 		if leechers := item.Torrent.Leechers(); leechers.Valid {
 			attrs = append(attrs, torznab.SearchResultItemTorznabAttr{
-				AttrName:  torznab.AttrPeers,
+				AttrName:  torznab.AttrLeechers,
 				AttrValue: strconv.Itoa(int(leechers.Uint)),
 			})
 		}
@@ -286,6 +287,7 @@ func (a adapter) transformSearchResult(req torznab.SearchRequest, res search.Tor
 			Title:    item.Torrent.Name,
 			Size:     item.Torrent.Size,
 			Category: category,
+			Comments: req.PermaLinkBase + item.InfoHash.String(),
 			GUID:     item.InfoHash.String(),
 			PubDate:  torznab.RssDate(item.PublishedAt),
 			Enclosure: torznab.SearchResultItemEnclosure{

--- a/internal/torznab/attributes.go
+++ b/internal/torznab/attributes.go
@@ -19,4 +19,5 @@ const (
 	AttrResolution = "resolution"
 	AttrTeam       = "team"
 	AttrImdb       = "imdb"
+	AttrTmdb       = "tmdb"
 )

--- a/internal/torznab/attributes.go
+++ b/internal/torznab/attributes.go
@@ -8,7 +8,7 @@ const (
 	AttrSize        = "size"
 	AttrPublishDate = "publishdate"
 	AttrSeeders     = "seeders"
-	AttrPeers       = "peers"
+	AttrLeechers    = "leechers"
 	// AttrFiles is the number of files in the torrent
 	AttrFiles   = "files"
 	AttrYear    = "year"

--- a/internal/torznab/request.go
+++ b/internal/torznab/request.go
@@ -5,15 +5,16 @@ import (
 )
 
 type SearchRequest struct {
-	Query    string
-	Type     string
-	Cats     []int
-	ImdbId   model.NullString
-	TmdbId   model.NullString
-	Season   model.NullInt
-	Episode  model.NullInt
-	Attrs    []string
-	Extended bool
-	Limit    model.NullUint
-	Offset   model.NullUint
+	Query         string
+	Type          string
+	Cats          []int
+	ImdbId        model.NullString
+	TmdbId        model.NullString
+	Season        model.NullInt
+	Episode       model.NullInt
+	Attrs         []string
+	Extended      bool
+	Limit         model.NullUint
+	Offset        model.NullUint
+	PermaLinkBase string
 }


### PR DESCRIPTION
This change enables clicking on found searches in Prowlarr, radarr and sonarr to view bitmagnet permalink details.

It is **odd** to have used `comments` attribute of torznab message.   This was assessed by scanning Prowlarr code for how it handles generic torznab indexers.    Also discovered that Prowlarr uses `leechers` not `peers` in constructing **peers n / m** column.  Where **n** is seeders and **m** is leachers.

Also explored using https://wiki.servarr.com/en/prowlarr/cardigann-yml-definition   This however results in significant duplication plus fixed list of base URLs.   Which really isn't good for a self hosted component where it cannot be pre-determined how someone is hosting and hence a static list of IPs / hostnames