### PR TITLE
chore: Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      gluetun:
+        condition: service_healthy
     command:
       - worker
       - run


### PR DESCRIPTION
`gluetun` may take a while before a VPN connection is established. Before that completes, `bitmagnet` will immediately start attempting to make connection attempts, which will fail.

`gluetun` provides a healthcheck via its `Dockerfile` (https://github.com/qdm12/gluetun-wiki/blob/main/faq/healthcheck.md) that we can make use of.