### PR TITLE
Allow slice values in configuration

### DIFF
--- a/internal/boilerplate/config/configfx/module.go
+++ b/internal/boilerplate/config/configfx/module.go
@@ -4,6 +4,7 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config"
 	"github.com/bitmagnet-io/bitmagnet/internal/boilerplate/config/configresolver"
+	"github.com/go-playground/validator/v10"
 	"go.uber.org/fx"
 	"os"
 	"strings"
@@ -23,10 +24,11 @@ func New() fx.Option {
 			fx.Provide(
 				fx.Annotated{
 					Group: "config_resolvers",
-					Target: func() (configresolver.Resolver, error) {
+					Target: func(val *validator.Validate) (configresolver.Resolver, error) {
 						return configresolver.NewFromYamlFile(
 							file,
 							false,
+							val,
 							configresolver.WithPriority(-i),
 						)
 					},
@@ -48,10 +50,11 @@ func New() fx.Option {
 		fx.Provide(
 			fx.Annotated{
 				Group: "config_resolvers",
-				Target: func() (configresolver.Resolver, error) {
+				Target: func(val *validator.Validate) (configresolver.Resolver, error) {
 					return configresolver.NewFromYamlFile(
 						"./config.yml",
 						true,
+						val,
 						configresolver.WithPriority(10),
 					)
 				},
@@ -63,10 +66,11 @@ func New() fx.Option {
 			fx.Provide(
 				fx.Annotated{
 					Group: "config_resolvers",
-					Target: func() (configresolver.Resolver, error) {
+					Target: func(val *validator.Validate) (configresolver.Resolver, error) {
 						return configresolver.NewFromYamlFile(
 							configFilePath,
 							true,
+							val,
 							configresolver.WithPriority(20),
 						)
 					},

--- a/internal/boilerplate/config/configfx/test_config.yaml
+++ b/internal/boilerplate/config/configfx/test_config.yaml
@@ -10,3 +10,8 @@ test:
       - 1
       - 2
       - 3
+  struct_slice:
+    - nested_key: FOO
+      int_with_validation: 1
+    - nested_key: BAR
+      int_with_validation: 2

--- a/internal/boilerplate/config/configresolver/mapresolver.go
+++ b/internal/boilerplate/config/configresolver/mapresolver.go
@@ -2,21 +2,25 @@ package configresolver
 
 import (
 	"fmt"
+	"github.com/go-playground/validator/v10"
+	"github.com/iancoleman/strcase"
+	"github.com/mitchellh/mapstructure"
 	"reflect"
 )
 
 type mapResolver struct {
 	baseResolver
-	m map[string]interface{}
+	validator *validator.Validate
+	m         map[string]interface{}
 }
 
-func NewMap(m map[string]interface{}, options ...Option) Resolver {
-	r := &mapResolver{m: m}
+func NewMap(m map[string]interface{}, val *validator.Validate, options ...Option) Resolver {
+	r := &mapResolver{m: m, validator: val}
 	r.applyOptions(append([]Option{WithKey("map")}, options...)...)
 	return r
 }
 
-func (r mapResolver) Resolve(path []string, valueType reflect.Type) (interface{}, bool, error) {
+func (r mapResolver) Resolve(path []string, valueType reflect.Type) (any, bool, error) {
 	if len(path) == 0 {
 		return r.m, true, nil
 	}
@@ -41,9 +45,41 @@ func (r mapResolver) Resolve(path []string, valueType reflect.Type) (interface{}
 					return nil, true, fmt.Errorf("error coercing config map path '%s' with value '%s' to type %v: %w", currentPath, strV, valueType, coerceErr)
 				}
 				return coerced, true, nil
+			} else if sliceV, sliceOk := rawV.([]interface{}); sliceOk {
+				resolvedSlice, err := r.resolveSlice(currentPath, sliceV, valueType)
+				return resolvedSlice, true, err
 			}
 			return rawV, true, nil
 		}
 	}
 	return nil, false, nil
+}
+
+func (r mapResolver) resolveSlice(currentPath []string, sliceV []any, valueType reflect.Type) (any, error) {
+	if valueType.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("received slice at path '%s', expected %s", currentPath, valueType.String())
+	}
+	var resolvedSlice []any
+	for _, sliceItem := range sliceV {
+		resolvedValue := reflect.New(valueType.Elem())
+		decoder, decoderErr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Result: resolvedValue.Interface(),
+			MatchName: func(mapKey, fieldName string) bool {
+				return mapKey == strcase.ToSnake(fieldName)
+			},
+		})
+		if decoderErr != nil {
+			return nil, decoderErr
+		}
+		if decodeErr := decoder.Decode(sliceItem); decodeErr != nil {
+			return nil, decodeErr
+		}
+		if valueType.Elem().Kind() == reflect.Struct {
+			if validateErr := r.validator.Struct(resolvedValue.Interface()); validateErr != nil {
+				return nil, validateErr
+			}
+		}
+		resolvedSlice = append(resolvedSlice, reflect.Indirect(resolvedValue).Interface())
+	}
+	return resolvedSlice, nil
 }

--- a/internal/boilerplate/config/configresolver/yaml.go
+++ b/internal/boilerplate/config/configresolver/yaml.go
@@ -1,11 +1,12 @@
 package configresolver
 
 import (
+	"github.com/go-playground/validator/v10"
 	"gopkg.in/yaml.v3"
 	"os"
 )
 
-func NewFromYamlFile(path string, ignoreMissing bool, options ...Option) (Resolver, error) {
+func NewFromYamlFile(path string, ignoreMissing bool, val *validator.Validate, options ...Option) (Resolver, error) {
 	m := make(map[string]interface{})
 	data, readErr := os.ReadFile(path)
 	if readErr != nil {
@@ -18,5 +19,5 @@ func NewFromYamlFile(path string, ignoreMissing bool, options ...Option) (Resolv
 			return nil, parseErr
 		}
 	}
-	return NewMap(m, append([]Option{WithKey(path)}, options...)...), nil
+	return NewMap(m, val, append([]Option{WithKey(path)}, options...)...), nil
 }


### PR DESCRIPTION
This PR allows config structs to include slice values with nested structs. This is required for implementing Torznab profiles.

cc @rraymondgh 