### PR TITLE
classifier multiple classifier*.yml configurations

### DIFF
--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -3,6 +3,8 @@ package classifier
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/bitmagnet-io/bitmagnet/internal/classifier/classification"
 	classifier_mocks "github.com/bitmagnet-io/bitmagnet/internal/classifier/mocks"
 	"github.com/bitmagnet-io/bitmagnet/internal/model"
@@ -10,7 +12,6 @@ import (
 	tmdb_mocks "github.com/bitmagnet-io/bitmagnet/internal/tmdb/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 func TestClassifier(t *testing.T) {
@@ -195,7 +196,7 @@ func TestClassifier(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("torrent: %s", tc.torrent.Name), func(t *testing.T) {
 			mocks := newTestClassifierMocks(t)
-			source, sourceErr := yamlSourceProvider{rawSourceProvider: coreSourceProvider{}}.source()
+			source, sourceErr := coreSourceProvider{}.provider().source()
 			if sourceErr != nil {
 				t.Fatal(sourceErr)
 				return

--- a/internal/classifier/json_schema_test.go
+++ b/internal/classifier/json_schema_test.go
@@ -3,9 +3,10 @@ package classifier
 import (
 	_ "embed"
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xeipuuv/gojsonschema"
-	"testing"
 )
 
 //go:embed json-schema.draft-07.json
@@ -24,7 +25,7 @@ func TestJsonSchema(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, metaResult.Valid())
 
-	coreClassifier, err := yamlSourceProvider{rawSourceProvider: coreSourceProvider{}}.source()
+	coreClassifier, err := coreSourceProvider{}.provider().source()
 	assert.NoError(t, err)
 	coreClassifierJson, err := json.Marshal(coreClassifier)
 	assert.NoError(t, err)


### PR DESCRIPTION
I have been running torznab profiles with tag filters.  **sonarr** RSS runs well,  when torrents are pre-tagged and filtered by these tags.  I have an hypothesis that 100 torrent limit means that **sonarr** does not poll all the torrents on content type filter alone. (I have not observed enough requests to torznab endpoint) Running a classifier config equivalent to:
```
flag_definitions:
  radarr: string_list
  sonarr: string_list
  sonarr_latest: string_list

workflows:
  tagcontent:
    - if_else:
        condition: "result.contentSource == 'tmdb' "
        if_action:
          add_tag: contentattached

  tagandkeep:
    # tag active content
    - find_match:
      - if_else:
          condition:
            and:
              - "result.contentType == contentType.tv_show"
              - "result.contentSource == 'tmdb' "
              - "result.contentId in flags.sonarr "
              - "result.episodes.filter(e, result.contentId + '_' + e in flags.sonarr_latest).size() > 0"
          if_action:
            add_tag: active
          else_action: unmatched

      - if_else:
          condition:
            and:
              - "result.contentType == contentType.tv_show"
              - "result.contentSource == 'tmdb' "
              - "result.contentId in flags.sonarr "
          if_action:
            add_tag: sonarr
          else_action: unmatched

      - if_else:
          condition:
            and:
              - "result.contentType == contentType.movie"
              - "result.contentSource == 'tmdb' "
              - "result.contentId in flags.radarr "
          if_action:
            add_tag: radarr
          else_action: unmatched

  tmdbproxy:
    - run_workflow: default
    - run_workflow: tagcontent
    - run_workflow: tagandkeep

```

This is far better server by keeping often changing `flag` lists in separate YaML files.   Hence reason for this PR.   Changing flag list files can be created with a scheduler,  currently with a restart of **bitmagnet**.

I will look into [fsnotify](https://github.com/fsnotify/fsnotify) for watching used YaML files to automatically trigger a regeneration of **CEL** environment as a subsequent change.

A few notes on implementation
- due to use of `filepath.Glob(glob)` code will not try to open a none existent file.   Hence no checking for that any more
- have mostly kept interfaces the same.   There are some,  hence amendments to two existing unit tests.   Have focused on de-duplication of code 