### PR TITLE
webui - development flexibility

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -120,7 +120,7 @@ tasks:
     cmds:
       - npm start -- --host {{.HOST}} --port {{.PORT}}
     vars:
-      HOST: localhost
+      HOST: 0.0.0.0
       PORT: 3334
 
   serve-docsite:

--- a/webui/src/environments/environment.ts
+++ b/webui/src/environments/environment.ts
@@ -1,1 +1,2 @@
-export const graphqlEndpoint = "http://localhost:3333/graphql";
+export const graphqlEndpoint =
+  window.location.protocol + "//" + window.location.hostname + ":3333/graphql";


### PR DESCRIPTION
Locking down to assuming all development is done on `localhost` eliminates 
- using a headless development server,   where there is no browser on server
- ability to rapidly view webui on multiple devices to ensure large and small dimension devices / screens currently show content as intended

