### PR TITLE
chart improvements - memorise hidden lines 

### DIFF
--- a/webui/src/app/charting/chart.component.ts
+++ b/webui/src/app/charting/chart.component.ts
@@ -1,6 +1,12 @@
 import { Component, inject, Input, OnInit } from "@angular/core";
 import { BaseChartDirective } from "ng2-charts";
-import { ChartConfiguration, ChartType } from "chart.js";
+import {
+  ChartConfiguration,
+  ChartType,
+  ChartEvent,
+  LegendItem,
+  LegendElement,
+} from "chart.js";
 import { Observable } from "rxjs";
 import { TranslocoDirective, TranslocoService } from "@jsverse/transloco";
 import {
@@ -35,6 +41,7 @@ export class ChartComponent<Data = unknown, Type extends ChartType = ChartType>
 {
   private themeInfo = inject(ThemeInfoService);
   private transloco = inject(TranslocoService);
+  private hiddenDatasets = new Map<string, boolean>();
 
   @Input() title: string;
   @Input() $data: Observable<Data> = new Observable();
@@ -67,9 +74,22 @@ export class ChartComponent<Data = unknown, Type extends ChartType = ChartType>
     this.updateChart();
   }
 
+  private legendOnClick(
+    e: ChartEvent,
+    item: LegendItem,
+    ctx: LegendElement<"line">,
+  ) {
+    const meta = ctx.chart.getDatasetMeta(item.datasetIndex!);
+    meta.hidden = !meta.hidden;
+    this.hiddenDatasets.set(meta.label, meta.hidden);
+    ctx.chart.update();
+  }
+
   private updateChart() {
     this.chartConfig = this.adapter.create(this.data, {
       legend: this.legend,
+      hiddenDatasets: this.hiddenDatasets,
+      legendOnClick: this.legendOnClick.bind(this),
     }) as ChartConfiguration;
   }
 }

--- a/webui/src/app/charting/types.ts
+++ b/webui/src/app/charting/types.ts
@@ -1,7 +1,21 @@
-import { ChartConfiguration, ChartType } from "chart.js";
+import {
+  ChartConfiguration,
+  ChartType,
+  ChartEvent,
+  LegendItem,
+  LegendElement,
+} from "chart.js";
+
+export type LegendOnClick = (
+  e: ChartEvent,
+  item: LegendItem,
+  ctx: LegendElement<"line">,
+) => void;
 
 export type FactoryParams = {
   legend: boolean;
+  hiddenDatasets: Map<string, boolean>;
+  legendOnClick: LegendOnClick;
 };
 
 export type ChartConfigFactory<

--- a/webui/src/app/dashboard/queue/queue-chart-adapter.timeline.ts
+++ b/webui/src/app/dashboard/queue/queue-chart-adapter.timeline.ts
@@ -75,13 +75,17 @@ export class QueueChartAdapterTimeline implements ChartAdapter<Result, "line"> {
                   0,
               );
             }
+            const label =
+              queue.queue +
+              ": " +
+              this.transloco.translate("dashboard.queues." + event);
             datasets.push({
               yAxisID: "yCount",
-              label:
-                queue.queue +
-                ": " +
-                this.transloco.translate("dashboard.queues." + event),
+              label: label,
               data: series,
+              hidden: params.hiddenDatasets.has(label)
+                ? params.hiddenDatasets.get(label)
+                : false,
               borderColor: colors[createThemeColor(eventColors[event], 50)],
               pointBackgroundColor:
                 colors[createThemeColor(eventColors[event], 20)],
@@ -114,12 +118,16 @@ export class QueueChartAdapterTimeline implements ChartAdapter<Result, "line"> {
                 }, null);
               latencySeries.push(result ? result[0] / result[1] : null);
             }
+            const label =
+              queue.queue +
+              ": " +
+              this.transloco.translate("dashboard.queues.latency");
             datasets.push({
               yAxisID: "yLatency",
-              label:
-                queue.queue +
-                ": " +
-                this.transloco.translate("dashboard.queues.latency"),
+              label: label,
+              hidden: params.hiddenDatasets.has(label)
+                ? params.hiddenDatasets.get(label)
+                : false,
               data: latencySeries,
               // fill: 'origin',
               // backgroundColor: 'rgba(148,159,177,0.2)',
@@ -163,6 +171,7 @@ export class QueueChartAdapterTimeline implements ChartAdapter<Result, "line"> {
         plugins: {
           legend: {
             display: params.legend,
+            onClick: params.legendOnClick,
           },
           decimation: {
             enabled: true,

--- a/webui/src/app/dashboard/torrents/torrent-chart-adapter.timeline.ts
+++ b/webui/src/app/dashboard/torrents/torrent-chart-adapter.timeline.ts
@@ -72,10 +72,14 @@ export class TorrentChartAdapterTimeline
                   ?.count ?? 0,
               );
             }
+            const label = [source.source, event].join("/");
             datasets.push({
               yAxisID: "yCount",
-              label: [source.source, event].join("/"),
+              label: label,
               data: series,
+              hidden: params.hiddenDatasets.has(label)
+                ? params.hiddenDatasets.get(label)
+                : false,
               borderColor: colors[createThemeColor(eventColors[event], 50)],
               pointBackgroundColor:
                 colors[createThemeColor(eventColors[event], 20)],
@@ -114,6 +118,7 @@ export class TorrentChartAdapterTimeline
         plugins: {
           legend: {
             display: params.legend,
+            onClick: params.legendOnClick,
           },
           decimation: {
             enabled: true,


### PR DESCRIPTION
When doing a bulk reclassify,   the y-axis is dominated by the created count.  To track progress of processed torrents,  it is convenient to hide created line by clicking on it in legend.  Then when chart refreshes for this hidden line to be memorised so action of hiding it does not need to be repeated.

Implementation does not modify chart post construction.

I have not yet done a `task build-webui`.   Will do that post initial review to keep it clear actual changed files.