### PR TITLE
Ipv6 enable

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -1,0 +1,12 @@
+postgres:
+  password: 123456789
+log:
+  level: debug
+dht_server:
+  addr: '::'
+  query_timeout: 8s
+dht_crawler:
+  bootstrap_nodes:
+    - 'router.utorrent.com:6881'
+    - 'router.bittorrent.com:6881'
+    - "router.silotis.us:6881"

--- a/internal/protocol/dht/client/server_adapter.go
+++ b/internal/protocol/dht/client/server_adapter.go
@@ -3,10 +3,11 @@ package client
 import (
 	"context"
 	"errors"
+	"net/netip"
+
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/dht"
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/dht/server"
-	"net/netip"
 )
 
 type serverAdapter struct {
@@ -92,12 +93,15 @@ func (a serverAdapter) SampleInfoHashes(ctx context.Context, addr netip.AddrPort
 }
 
 func extractNodes(msg dht.Msg) []NodeInfo {
-	if len(msg.R.Nodes) == 0 {
+	if len(msg.R.Nodes)+len(msg.R.Nodes6) == 0 {
 		return nil
 	}
-	nodes := make([]NodeInfo, 0, len(msg.R.Nodes))
+	nodes := make([]NodeInfo, 0, len(msg.R.Nodes)+len(msg.R.Nodes6))
 	for _, n := range msg.R.Nodes {
 		nodes = append(nodes, NodeInfo{ID: n.ID, Addr: n.Addr.ToAddrPort()})
+	}
+	for _, n6 := range msg.R.Nodes6 {
+		nodes = append(nodes, NodeInfo{ID: n6.ID, Addr: n6.Addr.ToAddrPort()})
 	}
 	return nodes
 }

--- a/internal/protocol/dht/nodeaddr.go
+++ b/internal/protocol/dht/nodeaddr.go
@@ -3,10 +3,11 @@ package dht
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/anacrolix/torrent/bencode"
 	"net"
 	"net/netip"
 	"strconv"
+
+	"github.com/anacrolix/torrent/bencode"
 )
 
 type NodeAddr struct {

--- a/internal/protocol/dht/nodeinfo.go
+++ b/internal/protocol/dht/nodeinfo.go
@@ -5,13 +5,14 @@ import (
 	"encoding"
 	"encoding/binary"
 	"fmt"
-	"github.com/anacrolix/missinggo/v2/slices"
-	"github.com/anacrolix/torrent/bencode"
-	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
 	"math"
 	"math/rand"
 	"net"
 	"reflect"
+
+	"github.com/anacrolix/missinggo/v2/slices"
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
 )
 
 type NodeInfo struct {

--- a/internal/protocol/dht/server/config.go
+++ b/internal/protocol/dht/server/config.go
@@ -5,11 +5,13 @@ import "time"
 type Config struct {
 	Port         uint16
 	QueryTimeout time.Duration
+	Addr         string
 }
 
 func NewDefaultConfig() Config {
 	return Config{
 		Port:         3334,
 		QueryTimeout: time.Second * 4,
+		Addr:         "0.0.0.0",
 	}
 }

--- a/internal/protocol/dht/server/socket.go
+++ b/internal/protocol/dht/server/socket.go
@@ -11,6 +11,6 @@ type Socket interface {
 	Receive([]byte) (int, netip.AddrPort, error)
 }
 
-func NewSocket() Socket {
-	return newSocket()
+func NewSocket(ip_type int) Socket {
+	return newSocket(ip_type)
 }

--- a/internal/protocol/dht/server/socket_unix.go
+++ b/internal/protocol/dht/server/socket_unix.go
@@ -10,8 +10,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func newSocket() Socket {
-	fd, sockErr := unix.Socket(unix.SOCK_DGRAM, unix.AF_INET, 0)
+func newSocket(ip_type int) Socket {
+	var fd int
+	var sockErr error
+	if ip_type == 4 {
+		fd, sockErr = unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	} else if ip_type == 6 {
+		fd, sockErr = unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, 0)
+	}
 	if sockErr != nil {
 		panic(fmt.Errorf("error creating socket: %w", sockErr))
 	}

--- a/internal/protocol/metainfo/metainforequester/requester.go
+++ b/internal/protocol/metainfo/metainforequester/requester.go
@@ -6,15 +6,16 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/anacrolix/torrent/bencode"
-	"github.com/anacrolix/torrent/peer_protocol"
-	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
-	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
 	"io"
 	"math"
 	"net"
 	"net/netip"
 	"time"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/peer_protocol"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/metainfo"
 )
 
 type Requester interface {
@@ -111,7 +112,14 @@ func (r requester) Request(ctx context.Context, infoHash protocol.ID, addr netip
 }
 
 func (r requester) connect(ctx context.Context, addr netip.AddrPort) (conn *net.TCPConn, err error) {
-	c, dialErr := r.dialer.DialContext(ctx, "tcp4", addr.String())
+	tcp := "tcp6"
+	if addr.Addr().Is4() {
+		tcp = "tcp4"
+	}
+	if addr.Addr().Is6() || addr.Addr().Is4In6() {
+		tcp = "tcp6"
+	}
+	c, dialErr := r.dialer.DialContext(ctx, tcp, addr.String())
 	if dialErr != nil {
 		err = dialErr
 		return


### PR DESCRIPTION
set dht_server.addr to '::' to enable both ipv4 and ipv6
set dht_server.addr to '0.0.0.0' to enable ipv4 only
set dht_server.addr to server's global ipv6 address to enable ipv6 only
currently only on linux