### PR TITLE
torznab permalinks 

### DIFF
--- a/internal/model/torrents.go
+++ b/internal/model/torrents.go
@@ -28,6 +28,10 @@ func (t *Torrent) AfterFind(_ *gorm.DB) error {
 	return nil
 }
 
+func (t Torrent) PermaLink(baseURL string) string {
+	return baseURL + "/webui/torrents/permalink/" + t.InfoHash.String()
+}
+
 // Seeders returns the highest number of seeders from all sources
 // todo: Add up bloom filters
 func (t Torrent) Seeders() NullUint {

--- a/internal/torznab/adapter/search_result.go
+++ b/internal/torznab/adapter/search_result.go
@@ -14,7 +14,7 @@ func torrentContentResultToTorznabResult(
 ) torznab.SearchResult {
 	entries := make([]torznab.SearchResultItem, 0, len(res.Items))
 	for _, item := range res.Items {
-		entries = append(entries, torrentContentResultItemToTorznabResultItem(item))
+		entries = append(entries, torrentContentResultItemToTorznabResultItem(item, req.Profile))
 	}
 
 	return torznab.SearchResult{
@@ -29,7 +29,8 @@ func torrentContentResultToTorznabResult(
 	}
 }
 
-func torrentContentResultItemToTorznabResultItem(item search.TorrentContentResultItem) torznab.SearchResultItem {
+func torrentContentResultItemToTorznabResultItem(
+	item search.TorrentContentResultItem, profile torznab.Profile) torznab.SearchResultItem {
 	category := "Unknown"
 	if item.ContentType.Valid {
 		category = item.ContentType.ContentType.Label()
@@ -78,6 +79,10 @@ func torrentContentResultItemToTorznabResultItem(item search.TorrentContentResul
 		{
 			AttrName:  torznab.AttrPublishDate,
 			AttrValue: item.PublishedAt.Format(torznab.RssDateDefaultFormat),
+		},
+		{
+			AttrName:  torznab.AttrCoverURL,
+			AttrValue: item.Torrent.PermaLink(profile.BaseURL),
 		},
 	}
 	seeders := item.Torrent.Seeders()
@@ -175,6 +180,8 @@ func torrentContentResultItemToTorznabResultItem(item search.TorrentContentResul
 		Category: category,
 		GUID:     item.InfoHash.String(),
 		PubDate:  torznab.RSSDate(item.PublishedAt),
+		Comments: item.Torrent.PermaLink(profile.BaseURL),
+		Link:     item.Torrent.PermaLink(profile.BaseURL),
 		Enclosure: torznab.SearchResultItemEnclosure{
 			URL:    item.Torrent.MagnetURI(),
 			Type:   "application/x-bittorrent;x-scheme-handler/magnet",

--- a/internal/torznab/attributes.go
+++ b/internal/torznab/attributes.go
@@ -21,4 +21,5 @@ const (
 	AttrTeam       = "team"
 	AttrImdb       = "imdb"
 	AttrTmdb       = "tmdb"
+	AttrCoverURL   = "coverurl"
 )

--- a/internal/torznab/profile.go
+++ b/internal/torznab/profile.go
@@ -9,6 +9,7 @@ type Profile struct {
 	DefaultLimit            uint
 	MaxLimit                uint
 	Tags                    []string
+	BaseURL                 string
 }
 
 var ProfileDefault = Profile{


### PR DESCRIPTION
baseURL can only be overridden in supplementary profile

replaces PR #377 as it was simpler to re-code than to merge on top of linter changes.