### PR TITLE
fix(search): query parser bug

### DIFF
--- a/internal/database/fts/tsquery.go
+++ b/internal/database/fts/tsquery.go
@@ -116,15 +116,13 @@ outer:
 			}
 			token := tokens[i]
 			addExpr := func(expr string) {
-				switch operator {
-				case OperatorAnd:
-					parts = append(parts, "&")
-				case OperatorOr:
-					parts = append(parts, "|")
-				case OperatorFollowedBy:
-					parts = append(parts, "<->")
-				default:
-					if len(parts) > 0 {
+				if len(parts) > 0 {
+					switch operator {
+					case OperatorOr:
+						parts = append(parts, "|")
+					case OperatorFollowedBy:
+						parts = append(parts, "<->")
+					default:
 						parts = append(parts, "&")
 					}
 				}

--- a/internal/database/fts/tsquery_test.go
+++ b/internal/database/fts/tsquery_test.go
@@ -1,8 +1,9 @@
-package fts
+package fts_test
 
 import (
 	"testing"
 
+	"github.com/bitmagnet-io/bitmagnet/internal/database/fts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,11 +33,12 @@ func TestAppQueryToTsquery(t *testing.T) {
 		{"Chinese", "给我做一个三明治", "Gei <-> Wo <-> Zuo <-> Yi <-> Ge <-> San <-> Ming <-> Zhi"},
 		{"Arabic", "اصنع لي شطيرة", "'Sn`' & ly & 'shTyr@'"},
 		{"Arabic (quoted)", "\"اصنع لي شطيرة\"", "'Sn`' <-> ly <-> 'shTyr@'"},
+		{"ampersand prefix", "&eacute;", "eacute"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, AppQueryToTsquery(tt.input))
+			assert.Equal(t, tt.want, fts.AppQueryToTsquery(tt.input))
 		})
 	}
 }

--- a/internal/database/fts/tsvector_test.go
+++ b/internal/database/fts/tsvector_test.go
@@ -1,8 +1,9 @@
-package fts
+package fts_test
 
 import (
 	"testing"
 
+	"github.com/bitmagnet-io/bitmagnet/internal/database/fts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,12 +13,12 @@ func TestParseTsvector(t *testing.T) {
 
 	tests := []struct {
 		input   string
-		wantTsv Tsvector
+		wantTsv fts.Tsvector
 		wantStr string
 	}{
 		{
 			input: " 'a':1A bb:2b 'cc ccc':3C  'dD''Dd''':4D e a bb:5 ",
-			wantTsv: Tsvector{
+			wantTsv: fts.Tsvector{
 				"a": {
 					1: 'A',
 				},
@@ -40,7 +41,7 @@ func TestParseTsvector(t *testing.T) {
 		t.Run(test.input, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := ParseTsvector(test.input)
+			got, err := fts.ParseTsvector(test.input)
 
 			require.NoError(t, err)
 			assert.Equal(t, test.wantTsv, got)


### PR DESCRIPTION
Fix a bug whereby search queries prefixed with special characters such as "&" would result in an invalid tsquery and a database error