### PR TITLE
Handle XXX results in torznab queries

### DIFF
--- a/internal/torznab/adapter/search_result.go
+++ b/internal/torznab/adapter/search_result.go
@@ -55,6 +55,8 @@ func torrentContentResultItemToTorznabResultItem(item search.TorrentContentResul
 			categoryID = torznab.CategoryPC.ID
 		case model.ContentTypeGame:
 			categoryID = torznab.CategoryPCGames.ID
+		case model.ContentTypeXxx:
+			categoryID = torznab.CategoryXXX.ID
 		}
 	}
 


### PR DESCRIPTION
A missing case in a switch caused all XXX items to be categorised as "other" when searching via torznab.