### PR TITLE
Use pointer to `StableBloomFilter`

### DIFF
--- a/internal/bloom/stable.go
+++ b/internal/bloom/stable.go
@@ -8,7 +8,7 @@ import (
 )
 
 type StableBloomFilter struct {
-	boom.StableBloomFilter
+	*boom.StableBloomFilter
 }
 
 const (
@@ -18,7 +18,7 @@ const (
 )
 
 func NewDefaultStableBloomFilter() *StableBloomFilter {
-	return &StableBloomFilter{*boom.NewStableBloomFilter(defaultCapacity, defaultD, defaultFpRate)}
+	return &StableBloomFilter{boom.NewStableBloomFilter(defaultCapacity, defaultD, defaultFpRate)}
 }
 
 func (s *StableBloomFilter) Scan(value interface{}) error {
@@ -32,7 +32,7 @@ func (s *StableBloomFilter) Scan(value interface{}) error {
 		return err
 	}
 
-	s.StableBloomFilter = *bf
+	s.StableBloomFilter = bf
 
 	return nil
 }


### PR DESCRIPTION
I got a nil pointer exception in the bloom filter and it looked like copying `boom.StableBloomFilter` by value may not be safe. This PR changes it to a pointer so it is guaranteed to be initialized correctly. The nil pointer exception has since gone away for me.