### PR TITLE
Implement BEP 0032 in the responder by adding a separate KTable

### DIFF
--- a/internal/protocol/dht/dhtfx/module.go
+++ b/internal/protocol/dht/dhtfx/module.go
@@ -21,6 +21,7 @@ func New() fx.Option {
 			},
 			client.New,
 			ktable.New,
+			ktable.NewFactory,
 			responder.New,
 			server.New,
 		),

--- a/internal/protocol/dht/ktable/factory.go
+++ b/internal/protocol/dht/ktable/factory.go
@@ -124,3 +124,9 @@ func patchPrometheusCollector[
 
 	return collector
 }
+
+func NewFactory(p Params) func() Table {
+	return func() Table {
+		return New(p).Table
+	}
+}

--- a/internal/protocol/dht/ktable/query.go
+++ b/internal/protocol/dht/ktable/query.go
@@ -83,16 +83,15 @@ type GetHashOrClosestNodes struct {
 }
 
 func (c GetHashOrClosestNodes) execReturn(t *table) GetHashOrClosestNodesResult {
+	closestNodes := t.nodes.getClosest(c.ID)
 	h, ok := t.hashes.get(c.ID)
 	if ok {
 		return GetHashOrClosestNodesResult{
-			Hash:  h,
-			Found: true,
+			Hash:         h,
+			ClosestNodes: closestNodes,
+			Found:        true,
 		}
 	}
-
-	closestNodes := t.nodes.getClosest(c.ID)
-
 	return GetHashOrClosestNodesResult{
 		ClosestNodes: closestNodes,
 	}

--- a/internal/protocol/dht/responder/factory.go
+++ b/internal/protocol/dht/responder/factory.go
@@ -15,7 +15,7 @@ import (
 
 type Params struct {
 	fx.In
-	KTable          ktable.Table
+	KTableFactory   func() ktable.Table
 	DiscoveredNodes concurrency.BatchingChannel[ktable.Node] `name:"dht_discovered_nodes"`
 	Logger          *zap.SugaredLogger
 }
@@ -35,10 +35,16 @@ const (
 )
 
 func New(p Params) Result {
+	v4table := p.KTableFactory()
+	v6table := p.KTableFactory()
+	if v4table.Origin() != v6table.Origin() {
+		panic("v4 and v6 tables have different origins")
+	}
 	collector := newPrometheusCollector(responderLimiter{
 		responder: responder{
-			nodeID:                   p.KTable.Origin(),
-			kTable:                   p.KTable,
+			nodeID:                   v4table.Origin(),
+			kTable:                   v4table,
+			kTable6:                  v6table,
 			tokenSecret:              protocol.RandomNodeID().Bytes(),
 			sampleInfoHashesInterval: 10,
 		},

--- a/internal/protocol/dht/responder/responder.go
+++ b/internal/protocol/dht/responder/responder.go
@@ -49,6 +49,7 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 		err = ErrMissingArguments
 		return
 	}
+	unmappedFromAddr := msg.From.Addr().Unmap()
 
 	ret.ID = r.nodeID
 
@@ -59,7 +60,7 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 			err = ErrMissingArguments
 			return
 		}
-		wantsV4, wantsV6 := r.wants(args, msg.From)
+		wantsV4, wantsV6 := r.wants(args, unmappedFromAddr)
 		if wantsV4 {
 			ret.Nodes = nodeInfosFromNodes(r.kTable.GetClosestNodes(args.Target)...)
 		}
@@ -71,12 +72,12 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 			err = ErrMissingArguments
 			return
 		}
-		wantsV4, wantsV6 := r.wants(args, msg.From)
+		wantsV4, wantsV6 := r.wants(args, unmappedFromAddr)
 
 		// Query v4 table if needed (for v4 nodes or values from a v4 request)
-		if wantsV4 || msg.From.Addr().Is4() {
+		if wantsV4 || unmappedFromAddr.Is4() {
 			result := r.kTable.GetHashOrClosestNodes(args.InfoHash)
-			if msg.From.Addr().Is4() && result.Found {
+			if unmappedFromAddr.Is4() && result.Found {
 				ret.Values = peersToNodeAddrs(result.Hash.Peers())
 			}
 			if wantsV4 {
@@ -85,9 +86,9 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 		}
 
 		// Query v6 table if needed (for v6 nodes or values from a v6 request)
-		if wantsV6 || msg.From.Addr().Is6() {
+		if wantsV6 || unmappedFromAddr.Is6() {
 			result := r.kTable6.GetHashOrClosestNodes(args.InfoHash)
-			if msg.From.Addr().Is6() && result.Found {
+			if unmappedFromAddr.Is6() && result.Found {
 				ret.Values = peersToNodeAddrs(result.Hash.Peers())
 			}
 			if wantsV6 {
@@ -95,7 +96,7 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 			}
 		}
 
-		token := r.announceToken(args.InfoHash, args.ID, msg.From.Addr())
+		token := r.announceToken(args.InfoHash, args.ID, unmappedFromAddr)
 		ret.Token = &token
 	case dht.QAnnouncePeer:
 		if args.InfoHash == [20]byte{} {
@@ -103,16 +104,16 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 			return
 		}
 
-		if args.Token != r.announceToken(args.InfoHash, args.ID, msg.From.Addr()) {
+		if args.Token != r.announceToken(args.InfoHash, args.ID, unmappedFromAddr) {
 			err = ErrInvalidToken
 			return
 		}
 
-		r.tableForAddr(msg.From.Addr()).BatchCommand(ktable.PutHash{ID: args.InfoHash, Peers: []ktable.HashPeer{{
-			Addr: netip.AddrPortFrom(msg.From.Addr(), msg.AnnouncePort()),
+		r.tableForAddr(unmappedFromAddr).BatchCommand(ktable.PutHash{ID: args.InfoHash, Peers: []ktable.HashPeer{{
+			Addr: netip.AddrPortFrom(unmappedFromAddr, msg.AnnouncePort()),
 		}}})
 	case dht.QSampleInfohashes:
-		result := r.tableForAddr(msg.From.Addr()).SampleHashesAndNodes()
+		result := r.tableForAddr(unmappedFromAddr).SampleHashesAndNodes()
 		samples := make(dht.CompactInfohashes, 0, len(result.Hashes))
 
 		for _, h := range result.Hashes {
@@ -120,9 +121,9 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 		}
 
 		ret.Samples = &samples
-		if msg.From.Addr().Is4() {
+		if unmappedFromAddr.Is4() {
 			ret.Nodes = nodeInfosFromNodes(result.Nodes...)
-		} else if msg.From.Addr().Is6() {
+		} else if unmappedFromAddr.Is6() {
 			ret.Nodes6 = nodeInfosFromNodes(result.Nodes...)
 		}
 		numInt64 := int64(result.TotalHashes)
@@ -143,7 +144,7 @@ func (r responder) tableForAddr(addr netip.Addr) ktable.Table {
 	return r.kTable
 }
 
-func (r responder) wants(args *dht.MsgArgs, from netip.AddrPort) (v4, v6 bool) {
+func (r responder) wants(args *dht.MsgArgs, from netip.Addr) (v4, v6 bool) {
 	if len(args.Want) > 0 {
 		for _, w := range args.Want {
 			switch w {
@@ -154,8 +155,8 @@ func (r responder) wants(args *dht.MsgArgs, from netip.AddrPort) (v4, v6 bool) {
 			}
 		}
 	}
-	v4 = v4 || from.Addr().Is4()
-	v6 = v6 || from.Addr().Is6()
+	v4 = v4 || from.Is4()
+	v6 = v6 || from.Is6()
 
 	return
 }

--- a/internal/protocol/dht/responder/responder.go
+++ b/internal/protocol/dht/responder/responder.go
@@ -18,6 +18,7 @@ type Responder interface {
 type responder struct {
 	nodeID                   protocol.ID
 	kTable                   ktable.Table
+	kTable6                  ktable.Table
 	tokenSecret              []byte
 	sampleInfoHashesInterval int64
 }
@@ -58,28 +59,42 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 			err = ErrMissingArguments
 			return
 		}
-
-		closestNodes := r.kTable.GetClosestNodes(args.Target)
-		ret.Nodes = nodeInfosFromNodes(closestNodes...)
+		wantsV4, wantsV6 := r.wants(args, msg.From)
+		if wantsV4 {
+			ret.Nodes = nodeInfosFromNodes(r.kTable.GetClosestNodes(args.Target)...)
+		}
+		if wantsV6 {
+			ret.Nodes6 = nodeInfosFromNodes(r.kTable6.GetClosestNodes(args.Target)...)
+		}
 	case dht.QGetPeers:
 		if args.InfoHash == [20]byte{} {
 			err = ErrMissingArguments
 			return
 		}
+		wantsV4, wantsV6 := r.wants(args, msg.From)
 
-		result := r.kTable.GetHashOrClosestNodes(args.InfoHash)
-		if result.Found {
-			hashPeers := result.Hash.Peers()
-			values := make([]dht.NodeAddr, 0, len(hashPeers))
-
-			for _, p := range hashPeers {
-				values = append(values, dht.NewNodeAddrFromAddrPort(p.Addr))
+		// Query v4 table if needed (for v4 nodes or values from a v4 request)
+		if wantsV4 || msg.From.Addr().Is4() {
+			result := r.kTable.GetHashOrClosestNodes(args.InfoHash)
+			if msg.From.Addr().Is4() && result.Found {
+				ret.Values = peersToNodeAddrs(result.Hash.Peers())
 			}
-
-			ret.Values = values
+			if wantsV4 {
+				ret.Nodes = nodeInfosFromNodes(result.ClosestNodes...)
+			}
 		}
 
-		ret.Nodes = nodeInfosFromNodes(result.ClosestNodes...)
+		// Query v6 table if needed (for v6 nodes or values from a v6 request)
+		if wantsV6 || msg.From.Addr().Is6() {
+			result := r.kTable6.GetHashOrClosestNodes(args.InfoHash)
+			if msg.From.Addr().Is6() && result.Found {
+				ret.Values = peersToNodeAddrs(result.Hash.Peers())
+			}
+			if wantsV6 {
+				ret.Nodes6 = nodeInfosFromNodes(result.ClosestNodes...)
+			}
+		}
+
 		token := r.announceToken(args.InfoHash, args.ID, msg.From.Addr())
 		ret.Token = &token
 	case dht.QAnnouncePeer:
@@ -93,11 +108,11 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 			return
 		}
 
-		r.kTable.BatchCommand(ktable.PutHash{ID: args.InfoHash, Peers: []ktable.HashPeer{{
+		r.tableForAddr(msg.From.Addr()).BatchCommand(ktable.PutHash{ID: args.InfoHash, Peers: []ktable.HashPeer{{
 			Addr: netip.AddrPortFrom(msg.From.Addr(), msg.AnnouncePort()),
 		}}})
 	case dht.QSampleInfohashes:
-		result := r.kTable.SampleHashesAndNodes()
+		result := r.tableForAddr(msg.From.Addr()).SampleHashesAndNodes()
 		samples := make(dht.CompactInfohashes, 0, len(result.Hashes))
 
 		for _, h := range result.Hashes {
@@ -105,7 +120,11 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 		}
 
 		ret.Samples = &samples
-		ret.Nodes = nodeInfosFromNodes(result.Nodes...)
+		if msg.From.Addr().Is4() {
+			ret.Nodes = nodeInfosFromNodes(result.Nodes...)
+		} else if msg.From.Addr().Is6() {
+			ret.Nodes6 = nodeInfosFromNodes(result.Nodes...)
+		}
 		numInt64 := int64(result.TotalHashes)
 		ret.Num = &numInt64
 		ret.Interval = &r.sampleInfoHashesInterval
@@ -115,6 +134,38 @@ func (r responder) Respond(_ context.Context, msg dht.RecvMsg) (ret dht.Return, 
 	}
 
 	return
+}
+
+func (r responder) tableForAddr(addr netip.Addr) ktable.Table {
+	if addr.Is6() {
+		return r.kTable6
+	}
+	return r.kTable
+}
+
+func (r responder) wants(args *dht.MsgArgs, from netip.AddrPort) (v4, v6 bool) {
+	if len(args.Want) > 0 {
+		for _, w := range args.Want {
+			switch w {
+			case dht.WantNodes:
+				v4 = true
+			case dht.WantNodes6:
+				v6 = true
+			}
+		}
+	}
+	v4 = v4 || from.Addr().Is4()
+	v6 = v6 || from.Addr().Is6()
+
+	return
+}
+
+func peersToNodeAddrs(peers []ktable.HashPeer) []dht.NodeAddr {
+	values := make([]dht.NodeAddr, 0, len(peers))
+	for _, p := range peers {
+		values = append(values, dht.NewNodeAddrFromAddrPort(p.Addr))
+	}
+	return values
 }
 
 // announceToken returns the token for an announce_peer request.

--- a/internal/protocol/dht/responder/responder_test.go
+++ b/internal/protocol/dht/responder/responder_test.go
@@ -17,8 +17,10 @@ import (
 type testResponderMocks struct {
 	nodeID    protocol.ID
 	table     *ktable_mocks.Table
+	table6    *ktable_mocks.Table
 	responder responder
 	sender    dht.NodeInfo
+	sender6   dht.NodeInfo
 }
 
 func newTestResponderMocks(t *testing.T) testResponderMocks {
@@ -26,16 +28,21 @@ func newTestResponderMocks(t *testing.T) testResponderMocks {
 
 	nodeID := protocol.RandomNodeID()
 	tableMock := ktable_mocks.NewTable(t)
+	table6Mock := ktable_mocks.NewTable(t)
 
 	return testResponderMocks{
 		nodeID: nodeID,
 		table:  tableMock,
+		table6: table6Mock,
 		responder: responder{
 			nodeID:                   nodeID,
 			kTable:                   tableMock,
+			kTable6:                  table6Mock,
+			tokenSecret:              protocol.RandomNodeID().Bytes(),
 			sampleInfoHashesInterval: 20,
 		},
-		sender: dht.RandomNodeInfo(4),
+		sender:  dht.RandomNodeInfo(4),
+		sender6: dht.RandomNodeInfo(16),
 	}
 }
 
@@ -156,6 +163,40 @@ func TestResponder_find_node(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestResponder_find_node__ipv6(t *testing.T) {
+	t.Parallel()
+
+	mocks := newTestResponderMocks(t)
+	target := protocol.RandomNodeID()
+	msg := dht.RecvMsg{
+		From: mocks.sender6.Addr.ToAddrPort(),
+		Msg: dht.Msg{
+			Q: "find_node",
+			A: &dht.MsgArgs{
+				ID:     mocks.sender6.ID,
+				Target: target,
+			},
+		},
+	}
+	nodes := dht.CompactIPv6NodeInfo{
+		dht.RandomNodeInfo(16),
+		dht.RandomNodeInfo(16),
+	}
+	peers := []ktable.Node{
+		mockedPeer{nodes[0]},
+		mockedPeer{nodes[1]},
+	}
+	mocks.table6.On("GetClosestNodes", target).Return(peers)
+	ret, err := mocks.responder.Respond(context.Background(), msg)
+	assert.Equal(t, dht.Return{
+		ID:     mocks.nodeID,
+		Nodes:  nil,
+		Nodes6: nodes,
+	}, ret)
+	assert.NoError(t, err)
+	mocks.table.AssertNotCalled(t, "GetClosestNodes")
+}
+
 func TestResponder_find_node__missing_target(t *testing.T) {
 	t.Parallel()
 
@@ -193,10 +234,14 @@ func TestResponder_get_peers__values(t *testing.T) {
 		dht.RandomNodeInfo(4),
 		dht.RandomNodeInfo(4),
 	}
+	closestNodes := []ktable.Node{
+		mockedPeer{dht.RandomNodeInfo(4)},
+	}
 	expectedToken := mocks.responder.announceToken(infoHash, mocks.sender.ID, mocks.sender.Addr.ToAddrPort().Addr())
 	mocks.table.On("GetHashOrClosestNodes", infoHash).Return(ktable.GetHashOrClosestNodesResult{
-		Hash:  mockedHash{nodeInfos: nodeInfos},
-		Found: true,
+		Hash:         mockedHash{nodeInfos: nodeInfos},
+		ClosestNodes: closestNodes,
+		Found:        true,
 	})
 
 	ret, err := mocks.responder.Respond(context.Background(), msg)
@@ -207,7 +252,7 @@ func TestResponder_get_peers__values(t *testing.T) {
 			nodeInfos[1].Addr,
 			nodeInfos[2].Addr,
 		},
-		Nodes: nil,
+		Nodes: nodeInfosFromNodes(closestNodes...),
 		Token: &expectedToken,
 	}, ret)
 	assert.NoError(t, err)
@@ -244,11 +289,12 @@ func TestResponder_get_peers__nodes(t *testing.T) {
 	})
 
 	ret, err := mocks.responder.Respond(context.Background(), msg)
+	assert.Equal(t, &expectedToken, ret.Token)
+	ret.Token = nil
 	assert.Equal(t, dht.Return{
 		ID:     mocks.nodeID,
 		Values: nil,
 		Nodes:  nodes,
-		Token:  &expectedToken,
 	}, ret)
 	assert.NoError(t, err)
 }
@@ -268,6 +314,93 @@ func TestResponder_get_peers__missing_info_hash(t *testing.T) {
 	}
 	_, err := mocks.responder.Respond(context.Background(), msg)
 	assert.Equal(t, ErrMissingArguments, err)
+}
+
+func TestResponder_get_peers__ipv6_values(t *testing.T) {
+	t.Parallel()
+
+	mocks := newTestResponderMocks(t)
+	infoHash := protocol.RandomNodeID()
+	msg := dht.RecvMsg{
+		From: mocks.sender6.Addr.ToAddrPort(),
+		Msg: dht.Msg{
+			Q: "get_peers",
+			A: &dht.MsgArgs{
+				ID:       mocks.sender6.ID,
+				InfoHash: infoHash,
+			},
+		},
+	}
+	nodeInfos := []dht.NodeInfo{
+		dht.RandomNodeInfo(16),
+		dht.RandomNodeInfo(16),
+	}
+	closestNodes := []ktable.Node{
+		mockedPeer{dht.RandomNodeInfo(16)},
+	}
+	expectedToken := mocks.responder.announceToken(infoHash, mocks.sender6.ID, mocks.sender6.Addr.ToAddrPort().Addr())
+	mocks.table6.On("GetHashOrClosestNodes", infoHash).Return(ktable.GetHashOrClosestNodesResult{
+		Hash:         mockedHash{nodeInfos: nodeInfos},
+		ClosestNodes: closestNodes,
+		Found:        true,
+	})
+
+	ret, err := mocks.responder.Respond(context.Background(), msg)
+	assert.Equal(t, &expectedToken, ret.Token)
+	ret.Token = nil
+	assert.Equal(t, dht.Return{
+		ID: mocks.nodeID,
+		Values: []dht.NodeAddr{
+			nodeInfos[0].Addr,
+			nodeInfos[1].Addr,
+		},
+		Nodes6: nodeInfosFromNodes(closestNodes...),
+	}, ret)
+	assert.NoError(t, err)
+	mocks.table.AssertNotCalled(t, "GetHashOrClosestNodes")
+}
+
+func TestResponder_get_peers__ipv4_want_n6(t *testing.T) {
+	t.Parallel()
+
+	mocks := newTestResponderMocks(t)
+	infoHash := protocol.RandomNodeID()
+	msg := dht.RecvMsg{
+		From: mocks.sender.Addr.ToAddrPort(),
+		Msg: dht.Msg{
+			Q: "get_peers",
+			A: &dht.MsgArgs{
+				ID:       mocks.sender.ID,
+				InfoHash: infoHash,
+				Want:     []dht.Want{dht.WantNodes6},
+			},
+		},
+	}
+	nodes6 := dht.CompactIPv6NodeInfo{
+		dht.RandomNodeInfo(16),
+	}
+	peers6 := []ktable.Node{
+		mockedPeer{nodes6[0]},
+	}
+	expectedToken := mocks.responder.announceToken(infoHash, mocks.sender.ID, mocks.sender.Addr.ToAddrPort().Addr())
+
+	// This will be called because the request is from an IPv4 address, but Nodes should not be populated
+	mocks.table.On("GetHashOrClosestNodes", infoHash).Return(ktable.GetHashOrClosestNodesResult{})
+
+	mocks.table6.On("GetHashOrClosestNodes", infoHash).Return(ktable.GetHashOrClosestNodesResult{
+		ClosestNodes: peers6,
+	})
+
+	ret, err := mocks.responder.Respond(context.Background(), msg)
+	assert.Equal(t, &expectedToken, ret.Token)
+	ret.Token = nil
+	assert.Equal(t, dht.Return{
+		ID:     mocks.nodeID,
+		Values: nil,
+		Nodes:  nil,
+		Nodes6: nodes6,
+	}, ret)
+	assert.NoError(t, err)
 }
 
 func TestResponder_announce_peer__implied_port(t *testing.T) {
@@ -337,6 +470,40 @@ func TestResponder_announce_peer__specified_port(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestResponder_announce_peer__ipv6(t *testing.T) {
+	t.Parallel()
+
+	mocks := newTestResponderMocks(t)
+	infoHash := protocol.RandomNodeID()
+	expectedToken := mocks.responder.announceToken(infoHash, mocks.sender6.ID, mocks.sender6.Addr.ToAddrPort().Addr())
+	msg := dht.RecvMsg{
+		From: mocks.sender6.Addr.ToAddrPort(),
+		Msg: dht.Msg{
+			Q: "announce_peer",
+			A: &dht.MsgArgs{
+				ID:          mocks.sender6.ID,
+				InfoHash:    infoHash,
+				Token:       expectedToken,
+				ImpliedPort: true,
+			},
+		},
+	}
+
+	mocks.table6.On("BatchCommand", ktable.PutHash{
+		ID: infoHash,
+		Peers: []ktable.HashPeer{{
+			Addr: mocks.sender6.Addr.ToAddrPort(),
+		}},
+	}).Return(nil)
+
+	ret, err := mocks.responder.Respond(context.Background(), msg)
+	assert.Equal(t, dht.Return{
+		ID: mocks.nodeID,
+	}, ret)
+	assert.NoError(t, err)
+	mocks.table.AssertNotCalled(t, "BatchCommand")
+}
+
 func TestResponder_sample_infohashes(t *testing.T) {
 	t.Parallel()
 
@@ -373,6 +540,7 @@ func TestResponder_sample_infohashes(t *testing.T) {
 	})
 
 	ret, err := mocks.responder.Respond(context.Background(), msg)
+	assert.Equal(t, &mocks.responder.sampleInfoHashesInterval, ret.Interval)
 	assert.Equal(t, dht.Return{
 		ID:    mocks.nodeID,
 		Nodes: nodes,
@@ -383,7 +551,50 @@ func TestResponder_sample_infohashes(t *testing.T) {
 				infoHashes[2].ID(),
 			},
 			Num:      &num,
-			Interval: &mocks.responder.sampleInfoHashesInterval,
+			Interval: ret.Interval,
+		},
+	}, ret)
+	assert.NoError(t, err)
+}
+
+func TestResponder_sample_infohashes__ipv6(t *testing.T) {
+	t.Parallel()
+
+	mocks := newTestResponderMocks(t)
+	msg := dht.RecvMsg{
+		From: mocks.sender6.Addr.ToAddrPort(),
+		Msg: dht.Msg{
+			Q: "sample_infohashes",
+			A: &dht.MsgArgs{
+				ID: mocks.sender6.ID,
+			},
+		},
+	}
+	infoHashes := []ktable.Hash{
+		mockedHash{id: protocol.RandomNodeID()},
+	}
+	nodes := dht.CompactIPv6NodeInfo{
+		dht.RandomNodeInfo(16),
+	}
+	peers := []ktable.Node{
+		mockedPeer{nodes[0]},
+	}
+	num := int64(123)
+	mocks.table6.On("SampleHashesAndNodes").Return(ktable.SampleHashesAndNodesResult{
+		Hashes:      infoHashes,
+		Nodes:       peers,
+		TotalHashes: int(num),
+	})
+
+	ret, err := mocks.responder.Respond(context.Background(), msg)
+	assert.Equal(t, &mocks.responder.sampleInfoHashesInterval, ret.Interval)
+	assert.Equal(t, dht.Return{
+		ID:     mocks.nodeID,
+		Nodes6: nodes,
+		Bep51Return: dht.Bep51Return{
+			Samples:  &dht.CompactInfohashes{infoHashes[0].ID()},
+			Num:      &num,
+			Interval: ret.Interval,
 		},
 	}, ret)
 	assert.NoError(t, err)


### PR DESCRIPTION
This shall close some of the gaps towards full IPv6 support.

I'll file more PRs to close the rest of the gaps if this is merged.