### PR TITLE
classifier delete tag foundations

### DIFF
--- a/internal/classifier/action_add_tag.go
+++ b/internal/classifier/action_add_tag.go
@@ -47,10 +47,10 @@ func (addTagAction) compileAction(ctx compilerContext) (action, error) {
 		func(ctx executionContext) (classification.Result, error) {
 			cl := ctx.result
 			if cl.Tags == nil {
-				cl.Tags = make(map[string]struct{})
+				cl.Tags = classification.NewTagAction()
 			}
 			for _, tag := range tags {
-				cl.Tags[tag] = struct{}{}
+				cl.Tags.Add[tag] = struct{}{}
 			}
 			return cl, nil
 		},

--- a/internal/classifier/classification/result.go
+++ b/internal/classifier/classification/result.go
@@ -2,10 +2,22 @@ package classification
 
 import "github.com/bitmagnet-io/bitmagnet/internal/model"
 
+type TagAction struct {
+	Add    map[string]struct{}
+	Delete map[string]struct{}
+}
+
+func NewTagAction() *TagAction {
+	return &TagAction{
+		Add:    make(map[string]struct{}),
+		Delete: make(map[string]struct{}),
+	}
+}
+
 type Result struct {
 	ContentAttributes
 	Content *model.Content
-	Tags    map[string]struct{}
+	Tags    *TagAction
 }
 
 func (r *Result) ApplyHint(h model.TorrentHint) {

--- a/internal/processor/persist.go
+++ b/internal/processor/persist.go
@@ -16,13 +16,15 @@ type persistPayload struct {
 	deleteIDs        []string
 	deleteInfoHashes []protocol.ID
 	addTags          map[protocol.ID]map[string]struct{}
+	deleteTags       map[protocol.ID]map[string]struct{}
 }
 
 func (c processor) persist(ctx context.Context, payload persistPayload) error {
 	contentsMap := make(map[model.ContentRef]struct{}, len(payload.torrentContents))
 	contentsPtr := make([]*model.Content, 0, len(payload.torrentContents))
 	torrentContentsPtr := make([]*model.TorrentContent, 0, len(payload.torrentContents))
-	torrentTagsPtr := make([]*model.TorrentTag, 0, len(payload.addTags))
+	torrentTagsAddPtr := make([]*model.TorrentTag, 0, len(payload.addTags))
+	torrentTagsDelPtr := make([]*model.TorrentTag, 0, len(payload.deleteTags))
 
 	for _, tc := range payload.torrentContents {
 		tcCopy := tc
@@ -43,7 +45,16 @@ func (c processor) persist(ctx context.Context, payload persistPayload) error {
 
 	for infoHash, tags := range payload.addTags {
 		for tag := range tags {
-			torrentTagsPtr = append(torrentTagsPtr, &model.TorrentTag{
+			torrentTagsAddPtr = append(torrentTagsAddPtr, &model.TorrentTag{
+				InfoHash: infoHash,
+				Name:     tag,
+			})
+		}
+	}
+
+	for infoHash, tags := range payload.deleteTags {
+		for tag := range tags {
+			torrentTagsDelPtr = append(torrentTagsDelPtr, &model.TorrentTag{
 				InfoHash: infoHash,
 				Name:     tag,
 			})
@@ -84,12 +95,22 @@ func (c processor) persist(ctx context.Context, payload persistPayload) error {
 			}
 		}
 
-		if len(torrentTagsPtr) > 0 {
+		if len(torrentTagsDelPtr) > 0 {
+			if _, deleteErr := tx.TorrentTag.WithContext(ctx).Clauses(
+				clause.OnConflict{
+					DoNothing: true,
+				},
+			).Delete(torrentTagsDelPtr...); deleteErr != nil {
+				return deleteErr
+			}
+		}
+
+		if len(torrentTagsAddPtr) > 0 {
 			if createErr := tx.TorrentTag.WithContext(ctx).Clauses(
 				clause.OnConflict{
 					DoNothing: true,
 				},
-			).CreateInBatches(torrentTagsPtr, 100); createErr != nil {
+			).CreateInBatches(torrentTagsAddPtr, 100); createErr != nil {
 				return createErr
 			}
 		}

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -92,6 +92,7 @@ func (c processor) Process(ctx context.Context, params MessageParams) error {
 	tcs := make([]model.TorrentContent, 0, len(searchResult.Torrents))
 
 	tagsToAdd := make(map[protocol.ID]map[string]struct{})
+	tagsToDelete := make(map[protocol.ID]map[string]struct{})
 
 	failedHashes := make([]protocol.ID, 0, len(searchResult.MissingInfoHashes))
 	failedHashes = append(failedHashes, searchResult.MissingInfoHashes...)
@@ -149,8 +150,14 @@ func (c processor) Process(ctx context.Context, params MessageParams) error {
 
 				tcs = append(tcs, torrentContent)
 
-				if len(cl.Tags) > 0 {
-					tagsToAdd[torrent.InfoHash] = cl.Tags
+				if cl.Tags != nil {
+					if len(cl.Tags.Add) > 0 {
+						tagsToAdd[torrent.InfoHash] = cl.Tags.Add
+					}
+
+					if len(cl.Tags.Delete) > 0 {
+						tagsToDelete[torrent.InfoHash] = cl.Tags.Delete
+					}
 				}
 			}
 		}(torrent)
@@ -189,6 +196,7 @@ func (c processor) Process(ctx context.Context, params MessageParams) error {
 		deleteIDs:        idsToDelete,
 		deleteInfoHashes: infoHashesToDelete,
 		addTags:          tagsToAdd,
+		deleteTags:       tagsToDelete,
 	})
 }
 


### PR DESCRIPTION
Currently I'm working on integrating Wasm plugins into classifier.   I'm building a few examples one of which is "delete_tag" as a Wasm plugin.

This requires that the `classifier.Result` struct can hold this information (as well as add_tag).   Plus this needs to be persisted to the database.

- In interest of keeping PRs small and easy to review this is a small change independent.  
- I elected not to create **action_delete_tag.go** 
