### PR TITLE
ubuntu 24.04+ apparmor chromium,  nix 24.11 golangci-lint

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,6 +24,7 @@ jobs:
           nix develop --ignore-environment --keep HOME . --command task lint
       # Adding golang-ci lint as a separate step as the Nix package is currently broken
       - name: golangci-lint
+        if: ${{ !env.ACT }}
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1.6
@@ -31,14 +32,14 @@ jobs:
 
   test:
     # The Ubuntu image has been downgraded and pinned for the `test` and `generated` jobs as they are broken on 24.04
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v26
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install web UI
+      - name: Install npm dependencies
         run: |
           nix develop --ignore-environment --command task install-webui
       - name: Run tests
@@ -47,7 +48,7 @@ jobs:
 
   # This job runs all code generations and builds the WebUI, to check that everything is correctly committed
   generated:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       # Label used to access the service container
       postgres:
@@ -79,9 +80,13 @@ jobs:
           nix develop --ignore-environment --keep HOME --keep POSTGRES_PASSWORD . --command task gen
           nix develop --ignore-environment --keep HOME . --command go fmt ./...
           nix develop --ignore-environment . --command task i18n-extract
-          nix develop --ignore-environment . --command task build-webui
         env:
           POSTGRES_PASSWORD: postgres
+      - name: build web app
+        # builds incorrect diffs when running in nektos/act
+        if: ${{ !env.ACT }}
+        run: |
+          nix develop --ignore-environment . --command task build-webui
       - name: Check nothing changed
         # excluding the 3rdpartylicenses file in a horrible hack:
-        run: git diff --exit-code -- . ':(exclude)webui/dist/bitmagnet/3rdpartylicenses.txt'
+        run: git diff --exit-code -- . ':(exclude)webui/dist/bitmagnet/3rdpartylicenses.txt' ':(exclude).github/workflows/*.yml'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,8 @@ linters:
     - whitespace
     - wsl
   settings:
+    usetesting:
+      context-background: false
     revive:
       rules:
         - name: argument-limit

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,6 @@ webui/dist/**/*.*
 webui/src/app/graphql/generated/**/*.*
 webui/src/app/i18n/translations/*.json
 webui/.angular
+plugins/assembly/**/*.*
+go-plugin/**/*.*
+webui/src/app/themes/*-theme.scss

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,8 +52,8 @@ tasks:
 
   lint:
     cmds:
-      # Removing golang-ci lint as the Nix package is currently broken
-      # - task lint-golangci
+      # golang-ci lint is from nix overlay
+      - task lint-golangci
       - task lint-webui
       - task lint-prettier
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732981179,
-        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,34 +3,55 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = {
-    nixpkgs,
-    flake-utils,
-    ...
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
-    pkgs = import nixpkgs {
-      system = system;
-    };
-    in {
-      formatter = pkgs.alejandra;
-      devShells = {
-        default = pkgs.mkShell {
-          packages = with pkgs; [
-            bundler
-            go
-            go-task
-            golangci-lint
-            jekyll
-            nodejs_22
-            nodePackages.prettier
-            protobuf
-            protoc-gen-go
-            ruby
-          ] ++ (if stdenv.isLinux then [
-            chromium
-          ] else []);
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+
+        lintOverlay = final: prev: {
+          golangci-lint = prev.callPackage ./nix/golangci-lint.nix { inherit (system) ; };
         };
-      };
-    });
+        pkgs = import nixpkgs {
+          system = system;
+          overlays = [
+            lintOverlay
+          ];
+        };
+
+      in
+      {
+        formatter = pkgs.alejandra;
+        devShells = {
+          default = pkgs.mkShell {
+            packages =
+              with pkgs;
+              [
+                bundler
+                go
+                go-task
+                golangci-lint
+                jekyll
+                nodejs_22
+                nodePackages.prettier
+                protobuf
+                protoc-gen-go
+                ruby
+              ]
+              ++ (
+                if stdenv.isLinux then
+                  [
+                    chromium
+                  ]
+                else
+                  [ ]
+              );
+          };
+        };
+      }
+    );
 }

--- a/nix/golangci-lint.nix
+++ b/nix/golangci-lint.nix
@@ -1,0 +1,54 @@
+{
+  buildGo124Module,
+  fetchFromGitHub,
+  lib,
+  installShellFiles,
+}:
+
+buildGo124Module rec {
+  pname = "golangci-lint-override";
+  version = "2.1.6";
+
+  src = fetchFromGitHub {
+    owner = "golangci";
+    repo = "golangci-lint";
+    rev = "v${version}";
+    hash = "sha256-L0TsVOUSU+nfxXyWsFLe+eU4ZxWbW3bHByQVatsTpXA=";
+  };
+
+  preBuild = ''
+    HOME=$TMPDIR
+  '';
+
+  vendorHash = "sha256-tYoAUumnHgA8Al3jKjS8P/ZkUlfbmmmBcJYUR7+5u9w=";
+
+  subPackages = [ "cmd/golangci-lint" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-X main.version=${version}"
+    "-X main.commit=v${version}"
+    "-X main.date=19700101-00:00:00"
+  ];
+
+  postInstall = ''
+    for shell in bash zsh fish; do
+      HOME=$TMPDIR $out/bin/golangci-lint completion $shell > golangci-lint.$shell
+      installShellCompletion golangci-lint.$shell
+    done
+  '';
+
+  meta = with lib; {
+    description = "Fast linters Runner for Go";
+    homepage = "https://golangci-lint.run/";
+    changelog = "https://github.com/golangci/golangci-lint/blob/v${version}/CHANGELOG.md";
+    mainProgram = "golangci-lint";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [
+      SuperSandro2000
+      mic92
+    ];
+  };
+}

--- a/webui/karma.conf.js
+++ b/webui/karma.conf.js
@@ -30,7 +30,13 @@ module.exports = function (config) {
       reporters: [{ type: "html" }, { type: "text-summary" }],
     },
     reporters: ["progress", "kjhtml"],
-    browsers: ["ChromeHeadless"],
+    browsers: ["ChromeHeadlessNoSandbox"],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"],
+      },
+    },
     restartOnFileChange: true,
   });
 };


### PR DESCRIPTION
## Fix up chromium sandboxing errors in GitHub actions
- [chromium apparmor](https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md).  Creating an additional apparmor profile does work on dev server (25.10).  However I could not find a way to apply to an action runner (using nekton/act)
- I tried using [disable apparmor](https://github.com/cisagov/action-disable-apparmor).  This does not work with nektos/act
- hence used approach of disabling sandboxing in karma

## gonlangci-lint
- have used an overlay in flake.  [nixos golangci-lint](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/by-name/go/golangci-lint/package.nix) with a small adaptation
- opted for overlay rather that changing channel to 25.04 so that no other packages are updated and need to re-generate code (notably protoc) and hence increasing size of this PR