### PR TITLE
Normalize bootstrap IPv4-mapped IPv6 addresses

### DIFF
--- a/internal/dhtcrawler/bootstrap.go
+++ b/internal/dhtcrawler/bootstrap.go
@@ -3,10 +3,25 @@ package dhtcrawler
 import (
 	"context"
 	"net"
+	"net/netip"
 	"time"
 
 	"github.com/bitmagnet-io/bitmagnet/internal/protocol/dht/ktable"
 )
+
+func ResolveBootstrapAddr(strAddr string) (netip.AddrPort, error) {
+	addr, err := net.ResolveUDPAddr("udp", strAddr)
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+
+	// Normalize IPv4-mapped IPv6 addresses so downstream DHT networking uses the IPv4 family.
+	if ip4 := addr.IP.To4(); ip4 != nil {
+		addr.IP = ip4
+	}
+
+	return addr.AddrPort(), nil
+}
 
 func (c *crawler) reseedBootstrapNodes(ctx context.Context) {
 	interval := time.Duration(0)
@@ -17,7 +32,7 @@ func (c *crawler) reseedBootstrapNodes(ctx context.Context) {
 			return
 		case <-time.After(interval):
 			for _, strAddr := range c.bootstrapNodes {
-				addr, err := net.ResolveUDPAddr("udp", strAddr)
+				addr, err := ResolveBootstrapAddr(strAddr)
 				if err != nil {
 					c.logger.Warnf("failed to resolve bootstrap node address: %s", err)
 					continue
@@ -25,7 +40,7 @@ func (c *crawler) reseedBootstrapNodes(ctx context.Context) {
 				select {
 				case <-ctx.Done():
 					return
-				case c.nodesForPing.In() <- ktable.NewNode(ktable.ID{}, addr.AddrPort()):
+				case c.nodesForPing.In() <- ktable.NewNode(ktable.ID{}, addr):
 					continue
 				}
 			}

--- a/internal/dhtcrawler/bootstrap_test.go
+++ b/internal/dhtcrawler/bootstrap_test.go
@@ -1,0 +1,28 @@
+package dhtcrawler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBootstrapAddrNormalizesIPv4MappedIPv6(t *testing.T) {
+	t.Parallel()
+
+	addr, err := ResolveBootstrapAddr("[::ffff:192.168.1.6]:40825")
+	require.NoError(t, err)
+
+	assert.True(t, addr.Addr().Is4())
+	assert.Equal(t, "192.168.1.6:40825", addr.String())
+}
+
+func TestResolveBootstrapAddrPreservesIPv6(t *testing.T) {
+	t.Parallel()
+
+	addr, err := ResolveBootstrapAddr("[2001:db8::1]:40825")
+	require.NoError(t, err)
+
+	assert.True(t, addr.Addr().Is6())
+	assert.Equal(t, "[2001:db8::1]:40825", addr.String())
+}

--- a/internal/dhtcrawler/dhtcrawlerfx/module.go
+++ b/internal/dhtcrawler/dhtcrawlerfx/module.go
@@ -1,7 +1,6 @@
 package dhtcrawlerfx
 
 import (
-	"net"
 	"net/netip"
 
 	adht "github.com/anacrolix/dht/v2"
@@ -21,11 +20,11 @@ func New() fx.Option {
 				Target: func() []netip.AddrPort {
 					addrs := make([]netip.AddrPort, 0, len(adht.DefaultGlobalBootstrapHostPorts))
 					for _, strAddr := range adht.DefaultGlobalBootstrapHostPorts {
-						addr, err := net.ResolveUDPAddr("udp", strAddr)
+						addr, err := dhtcrawler.ResolveBootstrapAddr(strAddr)
 						if err != nil {
 							panic(err)
 						}
-						addrs = append(addrs, addr.AddrPort())
+						addrs = append(addrs, addr)
 					}
 					return addrs
 				},


### PR DESCRIPTION
# Issue 437 PR Draft

Issue: [bitmagnet-io/bitmagnet#437](https://github.com/bitmagnet-io/bitmagnet/issues/437)  
Branch: `codex/fix-bootstrap-ipv4-mapped-ipv6`  
Commit: `e28e988`

## Suggested PR title

Normalize bootstrap IPv4-mapped IPv6 addresses

## Suggested PR body

Closes #437.

## Summary

This normalizes bootstrap addresses that resolve to IPv4-mapped IPv6 form such as `::ffff:192.168.1.6`, so the DHT client receives a real IPv4 address instead of an IPv6-mapped wrapper.

That addresses the reported `address family not supported by protocol` failures during bootstrap when hostnames are resolved through `extra_hosts` or `/etc/hosts`.

## What changed

- Added a shared `ResolveBootstrapAddr` helper in `internal/dhtcrawler/bootstrap.go`.
- Normalized resolved addresses with `IP.To4()` before converting them to `netip.AddrPort`.
- Reused that helper in both bootstrap resolution paths:
  - runtime reseeding in the crawler
  - default bootstrap node resolution in `dhtcrawlerfx`
- Added tests covering:
  - IPv4-mapped IPv6 normalization
  - native IPv6 passthrough

## Why this scope

This PR is intentionally limited to bootstrap address normalization. It does not change node selection policy, retry behavior, or the broader crawler design.

## Risk assessment

- Low risk.
- Native IPv6 addresses are preserved.
- True IPv4 addresses keep working.
- The normalization is applied only at bootstrap address resolution boundaries.

## Verification

Ran:

```bash
go test ./internal/dhtcrawler/...
go test ./...
```

## Files changed

- `internal/dhtcrawler/bootstrap.go`
- `internal/dhtcrawler/bootstrap_test.go`
- `internal/dhtcrawler/dhtcrawlerfx/module.go`
