### PR TITLE
Fix double-dot file extension parsing

### DIFF
--- a/internal/model/torrent_files.go
+++ b/internal/model/torrent_files.go
@@ -30,12 +30,20 @@ func (f TorrentFile) BaseName() string {
 	return basePathParts[len(basePathParts)-1]
 }
 
-var fileExtensionRegex = regexp.MustCompile(`[^/.]\.([a-z0-9]+)$`)
+var fileExtensionRegex = regexp.MustCompile(`^[a-z0-9]+$`)
 
 func FileExtensionFromPath(path string) NullString {
-	match := fileExtensionRegex.FindStringSubmatch(strings.ToLower(path))
-	if len(match) == 2 {
-		return NewNullString(match[1])
+	path = strings.ToLower(path)
+
+	lastSlashIndex := strings.LastIndexByte(path, '/')
+	lastDotIndex := strings.LastIndexByte(path, '.')
+	if lastDotIndex <= lastSlashIndex+1 || lastDotIndex == len(path)-1 {
+		return NullString{}
+	}
+
+	ext := path[lastDotIndex+1:]
+	if fileExtensionRegex.MatchString(ext) {
+		return NewNullString(ext)
 	}
 
 	return NullString{}

--- a/internal/model/torrent_files_test.go
+++ b/internal/model/torrent_files_test.go
@@ -1,0 +1,73 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileExtensionFromPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		path      string
+		wantExt   string
+		wantValid bool
+	}{
+		{
+			name:      "simple extension",
+			path:      "short film.mkv",
+			wantExt:   "mkv",
+			wantValid: true,
+		},
+		{
+			name:      "multi part extension",
+			path:      "short film.mkv.mk2",
+			wantExt:   "mk2",
+			wantValid: true,
+		},
+		{
+			name:      "double dot before extension",
+			path:      "short film..mkv",
+			wantExt:   "mkv",
+			wantValid: true,
+		},
+		{
+			name:      "triple dot before extension",
+			path:      "short film...mkv",
+			wantExt:   "mkv",
+			wantValid: true,
+		},
+		{
+			name:      "hidden file is not treated as an extension",
+			path:      ".mkv",
+			wantValid: false,
+		},
+		{
+			name:      "hidden file in nested path is not treated as an extension",
+			path:      "Movies/.mkv",
+			wantValid: false,
+		},
+		{
+			name:      "trailing dot is invalid",
+			path:      "short film.",
+			wantValid: false,
+		},
+		{
+			name:      "extension with punctuation is invalid",
+			path:      "short film.m-kv",
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FileExtensionFromPath(tt.path)
+			assert.Equal(t, tt.wantValid, got.Valid)
+			assert.Equal(t, tt.wantExt, got.String)
+		})
+	}
+}


### PR DESCRIPTION
# Issue 414 PR Draft

Issue: [bitmagnet-io/bitmagnet#414](https://github.com/bitmagnet-io/bitmagnet/issues/414)  
Branch: `codex/fix-double-dot-extension-parsing`  
Commit: `ce30d70`

## Suggested PR title

Fix double-dot file extension parsing

## Suggested PR body

Closes #414.

## Summary

This changes the file extension parser so filenames like `name..mkv` and `name...mkv` are treated as having a valid `mkv` extension instead of being classified as extensionless.

The previous implementation used a regex that rejected any final extension if the character before the separating dot was itself a dot. That made dotted suffix patterns fail even though the actual extension token at the end of the filename was valid.

## What changed

- Switched `FileExtensionFromPath` from a single end-of-string regex capture to explicit last-dot parsing.
- Kept existing guards for invalid cases such as hidden files and trailing dots.
- Added coverage for:
  - normal extensions
  - multi-part extensions
  - double-dot filenames
  - triple-dot filenames
  - hidden files
  - trailing dots
  - invalid punctuation in extensions

## Why this scope

This PR is intentionally limited to extension extraction. It does not change broader classification heuristics, UI behavior, or database schema.

## Risk assessment

- Low risk.
- The change is isolated to extension parsing.
- Existing valid filenames continue to parse the same way.
- Invalid edge cases remain rejected.

## Verification

Ran:

```bash
go test ./internal/model/...
go test ./...
```

## Files changed

- `internal/model/torrent_files.go`
- `internal/model/torrent_files_test.go`
