### PR TITLE
Truncate oversized torrent content tsvectors

### DIFF
--- a/internal/model/torrent_contents.go
+++ b/internal/model/torrent_contents.go
@@ -7,6 +7,8 @@ import (
 	"github.com/bitmagnet-io/bitmagnet/internal/database/fts"
 )
 
+const maxPostgresTsvectorBytes = 1<<20 - 1
+
 func (tc TorrentContent) InferID() string {
 	parts := make([]string, 4)
 	parts[0] = tc.InfoHash.String()
@@ -63,7 +65,7 @@ func (tc TorrentContent) ContentRef() Maybe[ContentRef] {
 	return Maybe[ContentRef]{}
 }
 
-func (tc *TorrentContent) UpdateTsv() {
+func (tc TorrentContent) baseTsv() fts.Tsvector {
 	var tsv fts.Tsvector
 	if !tc.ContentID.Valid {
 		tsv = fts.Tsvector{}
@@ -98,9 +100,41 @@ func (tc *TorrentContent) UpdateTsv() {
 	tsv.AddText(tc.InfoHash.String(), fts.TsvectorWeightA)
 	tsv.AddText(tc.Torrent.Name, fts.TsvectorWeightA)
 
-	for _, str := range tc.Torrent.fileSearchStrings() {
+	return tsv
+}
+
+func buildTruncatedTsvector(base fts.Tsvector, fileSearchStrings []string, maxBytes int) fts.Tsvector {
+	tsv := base.Copy()
+
+	for _, str := range fileSearchStrings {
+		next := tsv.Copy()
+		next.AddText(str, fts.TsvectorWeightD)
+		if len(next.String()) > maxBytes {
+			break
+		}
+
+		tsv = next
+	}
+
+	return tsv
+}
+
+func (tc *TorrentContent) updateTsv(maxBytes int) {
+	baseTsv := tc.baseTsv()
+	fileSearchStrings := tc.Torrent.fileSearchStrings()
+
+	tsv := baseTsv.Copy()
+	for _, str := range fileSearchStrings {
 		tsv.AddText(str, fts.TsvectorWeightD)
 	}
 
+	if len(tsv.String()) > maxBytes {
+		tsv = buildTruncatedTsvector(baseTsv, fileSearchStrings, maxBytes)
+	}
+
 	tc.Tsv = tsv
+}
+
+func (tc *TorrentContent) UpdateTsv() {
+	tc.updateTsv(maxPostgresTsvectorBytes)
 }

--- a/internal/model/torrent_contents_test.go
+++ b/internal/model/torrent_contents_test.go
@@ -1,0 +1,58 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateTsvKeepsAllFileSearchStringsWhenWithinLimit(t *testing.T) {
+	t.Parallel()
+
+	tc := TorrentContent{
+		InfoHash: protocol.MustParseID("0102030405060708090a0b0c0d0e0f1011121314"),
+		Torrent: Torrent{
+			Name: "example torrent release",
+			Files: []TorrentFile{
+				{Path: "dir/" + strings.Repeat("a", 40) + ".txt"},
+				{Path: "dir/" + strings.Repeat("b", 40) + ".txt"},
+			},
+		},
+	}
+
+	tc.updateTsv(10_000)
+
+	assert.Contains(t, tc.Tsv, strings.Repeat("a", 40))
+	assert.Contains(t, tc.Tsv, strings.Repeat("b", 40))
+}
+
+func TestUpdateTsvTruncatesFileSearchStringsWhenLimitExceeded(t *testing.T) {
+	t.Parallel()
+
+	firstLexeme := strings.Repeat("a", 180)
+	thirdLexeme := strings.Repeat("c", 180)
+
+	tc := TorrentContent{
+		InfoHash: protocol.MustParseID("0102030405060708090a0b0c0d0e0f1011121314"),
+		Torrent: Torrent{
+			Name: "example torrent release",
+			Files: []TorrentFile{
+				{Path: "dir/" + firstLexeme + ".txt"},
+				{Path: "dir/" + strings.Repeat("b", 180) + ".txt"},
+				{Path: "dir/" + thirdLexeme + ".txt"},
+			},
+		},
+	}
+
+	tc.updateTsv(500)
+
+	assert.LessOrEqual(t, len(tc.Tsv.String()), 500)
+	assert.Contains(t, tc.Tsv, tc.InfoHash.String())
+	assert.Contains(t, tc.Tsv, "example")
+	assert.Contains(t, tc.Tsv, "torrent")
+	assert.Contains(t, tc.Tsv, "release")
+	assert.Contains(t, tc.Tsv, firstLexeme)
+	assert.NotContains(t, tc.Tsv, thirdLexeme)
+}


### PR DESCRIPTION
# Issue 410 PR Draft

Issue: [bitmagnet-io/bitmagnet#410](https://github.com/bitmagnet-io/bitmagnet/issues/410)  
Branch: `codex/truncate-oversized-tsvector`  
Commit: `c1722a6`

## Suggested PR title

Truncate oversized torrent content tsvectors

## Suggested PR body

Closes #410.

## Summary

This adds a fallback path when building `TorrentContent.Tsv` so torrents with extremely large file-path search terms do not fail processing with PostgreSQL's `string is too long for tsvector` error.

The new behavior preserves the higher-value search terms first, including:

- inherited content TSV data
- content metadata fields
- info hash
- torrent name

If adding all derived file search strings would push the serialized `tsvector` past PostgreSQL's hard size limit, the code now keeps appending low-priority file-path terms until the limit would be exceeded, then stops.

## What changed

- Split TSV construction into:
  - a base vector builder for high-priority terms
  - a truncating builder for low-priority file-path terms
- Added a hard cap matching PostgreSQL's documented maximum `tsvector` size
- Kept the existing full behavior when the generated vector fits within the limit
- Added tests covering:
  - normal non-truncated indexing
  - bounded truncation when the synthetic size limit is exceeded

## Why this scope

This PR is intentionally limited to preventing job failure on oversized `tsvector` generation. It does not redesign ranking, tokenization, or search schema behavior.

## Risk assessment

- Moderate but controlled.
- Search quality for pathological oversized torrents may drop slightly because some low-priority file-path terms are omitted.
- The fallback is deterministic and preserves the most important search keys first.
- The alternative today is full job failure for those torrents.

## Verification

Ran:

```bash
go test ./internal/model/...
go test ./...
```

## Files changed

- `internal/model/torrent_contents.go`
- `internal/model/torrent_contents_test.go`
