### PR TITLE
Deduplicate discovered nodes with a stable bloom filter

### DIFF
--- a/internal/dhtcrawler/crawler.go
+++ b/internal/dhtcrawler/crawler.go
@@ -49,6 +49,7 @@ type crawler struct {
 	// This avoids multiple attempts to crawl the same hash, and takes a lot of load off the database query
 	// that checks if a hash has already been indexed.
 	ignoreHashes    *ignoreHashes
+	seenNodes       *seenNodes
 	blockingManager blocking.Manager
 	// soughtNodeID is a random node ID used as the target for find_node and sample_infohashes requests.
 	// It is rotated every 10 seconds.
@@ -106,11 +107,33 @@ type ignoreHashes struct {
 	bloom *boom.StableBloomFilter
 }
 
+type testAndAdder interface {
+	TestAndAdd([]byte) bool
+}
+
+type seenNodes struct {
+	mutex sync.Mutex
+	bloom testAndAdder
+}
+
 func (i *ignoreHashes) testAndAdd(id protocol.ID) bool {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
 
 	return i.bloom.TestAndAdd(id[:])
+}
+
+func newSeenNodes() *seenNodes {
+	return &seenNodes{
+		bloom: boom.NewStableBloomFilter(10_000_000, 2, 0.001),
+	}
+}
+
+func (s *seenNodes) testAndAdd(addr netip.Addr) bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.bloom.TestAndAdd(addr.Unmap().AsSlice())
 }
 
 func (c *crawler) rotateSoughtNodeID(ctx context.Context) {

--- a/internal/dhtcrawler/discovered_nodes.go
+++ b/internal/dhtcrawler/discovered_nodes.go
@@ -2,7 +2,6 @@ package dhtcrawler
 
 import (
 	"context"
-	"net/netip"
 	"time"
 
 	"github.com/bitmagnet-io/bitmagnet/internal/concurrency"
@@ -36,20 +35,7 @@ func (c *crawler) runDiscoveredNodes(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case ps := <-c.discoveredNodes.Out():
-			addrs := make([]netip.Addr, 0, 1)
-
-			m := make(map[string]ktable.Node, 1)
-			for _, p := range ps {
-				if _, ok := m[p.Addr().Addr().String()]; !ok {
-					m[p.Addr().Addr().String()] = p
-					addrs = append(addrs, p.Addr().Addr())
-				}
-			}
-			// for any discovered node not already in the routing table,
-			// we will block until it can be sent to any one of the pipeline channels.
-			unknownAddrs := c.kTable.FilterKnownAddrs(addrs)
-			for _, addr := range unknownAddrs {
-				p := m[addr.String()]
+			for _, p := range c.filterDiscoveredNodes(ps) {
 				select {
 				case <-ctx.Done():
 					return
@@ -60,4 +46,27 @@ func (c *crawler) runDiscoveredNodes(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func (c *crawler) filterDiscoveredNodes(nodes []ktable.Node) []ktable.Node {
+	filtered := make([]ktable.Node, 0, len(nodes))
+	seenInBatch := make(map[string]struct{}, len(nodes))
+
+	for _, node := range nodes {
+		addr := node.Addr().Addr().Unmap()
+		addrKey := addr.String()
+
+		if _, ok := seenInBatch[addrKey]; ok {
+			continue
+		}
+		seenInBatch[addrKey] = struct{}{}
+
+		if c.seenNodes != nil && c.seenNodes.testAndAdd(addr) {
+			continue
+		}
+
+		filtered = append(filtered, node)
+	}
+
+	return filtered
 }

--- a/internal/dhtcrawler/discovered_nodes_test.go
+++ b/internal/dhtcrawler/discovered_nodes_test.go
@@ -1,0 +1,67 @@
+package dhtcrawler
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol/dht/ktable"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTestAndAdder struct {
+	seen map[string]struct{}
+}
+
+func (f *fakeTestAndAdder) TestAndAdd(data []byte) bool {
+	if f.seen == nil {
+		f.seen = make(map[string]struct{})
+	}
+
+	key := string(data)
+	_, ok := f.seen[key]
+	f.seen[key] = struct{}{}
+
+	return ok
+}
+
+func TestFilterDiscoveredNodesSkipsRecentlySeenAddrs(t *testing.T) {
+	c := crawler{
+		seenNodes: &seenNodes{
+			bloom: &fakeTestAndAdder{},
+		},
+	}
+
+	firstBatch := []ktable.Node{
+		testNode("1111111111111111111111111111111111111111", "203.0.113.10:6881"),
+		testNode("2222222222222222222222222222222222222222", "203.0.113.10:49001"),
+		testNode("3333333333333333333333333333333333333333", "203.0.113.11:6881"),
+	}
+
+	filtered := c.filterDiscoveredNodes(firstBatch)
+	require.Len(t, filtered, 2)
+	require.Equal(t, firstBatch[0].Addr(), filtered[0].Addr())
+	require.Equal(t, firstBatch[2].Addr(), filtered[1].Addr())
+
+	secondBatch := []ktable.Node{
+		testNode("4444444444444444444444444444444444444444", "203.0.113.10:6881"),
+		testNode("5555555555555555555555555555555555555555", "203.0.113.12:6881"),
+	}
+
+	filtered = c.filterDiscoveredNodes(secondBatch)
+	require.Len(t, filtered, 1)
+	require.Equal(t, secondBatch[1].Addr(), filtered[0].Addr())
+}
+
+func TestSeenNodesNormalizesIPv4MappedIPv6(t *testing.T) {
+	seen := seenNodes{
+		bloom: &fakeTestAndAdder{},
+	}
+
+	require.False(t, seen.testAndAdd(netip.MustParseAddr("::ffff:203.0.113.10")))
+	require.True(t, seen.testAndAdd(netip.MustParseAddr("203.0.113.10")))
+}
+
+func testNode(id string, addr string) ktable.Node {
+	return ktable.NewNode(protocol.MustParseID(id), netip.MustParseAddrPort(addr))
+}

--- a/internal/dhtcrawler/factory.go
+++ b/internal/dhtcrawler/factory.go
@@ -120,6 +120,7 @@ func New(params Params) Result {
 						ignoreHashes: &ignoreHashes{
 							bloom: boom.NewStableBloomFilter(10_000_000, 2, 0.001),
 						},
+						seenNodes:       newSeenNodes(),
 						blockingManager: blockingManager,
 						soughtNodeID:    &concurrency.AtomicValue[protocol.ID]{},
 						stopped:         make(chan struct{}),


### PR DESCRIPTION
## Summary
- replace discovered-node filtering based on `ktable` membership with a dedicated stable bloom filter of recently seen node addresses
- keep in-batch deduping by address so the same IP is only enqueued once per batch
- add focused tests covering recent-address suppression and IPv4-mapped IPv6 normalization

## Rationale
Issue #433 describes the crawler revisiting the same nodes many times in a short window because `discovered_nodes` currently relies on `ktable.FilterKnownAddrs`, which does not reflect every recently seen node.

In the issue discussion, @mgdigital suggested using a stable bloom filter like the existing seen-hash filter so memory usage stays bounded and nodes can naturally age back in over time. This change applies that approach directly in `discovered_nodes`, keeping the fix local to crawler deduplication instead of treating the routing table as the source of truth for recently seen nodes.

## Testing
- `go test ./internal/dhtcrawler/...`
- `go test ./...`

Closes bitmagnet-io/bitmagnet#433