### PR TITLE
Resolve nested torrent.files in GraphQL search results

### DIFF
--- a/internal/gql/gql.gen.go
+++ b/internal/gql/gql.gen.go
@@ -453,6 +453,7 @@ type QueueQueryResolver interface {
 	Jobs(ctx context.Context, obj *gqlmodel.QueueQuery, input gqlmodel.QueueJobsQueryInput) (gqlmodel.QueueJobsQueryResult, error)
 }
 type TorrentResolver interface {
+	Files(ctx context.Context, obj *model.Torrent) ([]model.TorrentFile, error)
 	Sources(ctx context.Context, obj *model.Torrent) ([]gqlmodel.TorrentSourceInfo, error)
 }
 type TorrentMutationResolver interface {
@@ -9113,7 +9114,7 @@ func (ec *executionContext) _Torrent_files(ctx context.Context, field graphql.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Files, nil
+		return ec.resolvers.Torrent().Files(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -9131,8 +9132,8 @@ func (ec *executionContext) fieldContext_Torrent_files(_ context.Context, field 
 	fc = &graphql.FieldContext{
 		Object:     "Torrent",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "infoHash":
@@ -18794,7 +18795,38 @@ func (ec *executionContext) _Torrent(ctx context.Context, sel ast.SelectionSet, 
 		case "fileTypes":
 			out.Values[i] = ec._Torrent_fileTypes(ctx, field, obj)
 		case "files":
-			out.Values[i] = ec._Torrent_files(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Torrent_files(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "sources":
 			field := field
 

--- a/internal/gql/gqlgen.yml
+++ b/internal/gql/gqlgen.yml
@@ -168,6 +168,12 @@ models:
   FacetAggregationInput:
     model:
       - github.com/bitmagnet-io/bitmagnet/internal/database/query.FacetAggregationConfig
+  Torrent:
+    model:
+      - github.com/bitmagnet-io/bitmagnet/internal/model.Torrent
+    fields:
+      files:
+        resolver: true
   QueueMetricsBucket:
     model:
       - github.com/bitmagnet-io/bitmagnet/internal/metrics/queuemetrics.Bucket

--- a/internal/gql/resolvers/models.resolvers.go
+++ b/internal/gql/resolvers/models.resolvers.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/bitmagnet-io/bitmagnet/internal/gql"
 	"github.com/bitmagnet-io/bitmagnet/internal/gql/gqlmodel"
+	"github.com/bitmagnet-io/bitmagnet/internal/gql/gqlmodel/gen"
 	"github.com/bitmagnet-io/bitmagnet/internal/model"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
 )
 
 // OriginalLanguage is the resolver for the originalLanguage field.
@@ -20,6 +22,34 @@ func (r *contentResolver) OriginalLanguage(ctx context.Context, obj *model.Conte
 	}
 
 	return language, nil
+}
+
+// Files is the resolver for the files field.
+func (r *torrentResolver) Files(ctx context.Context, obj *model.Torrent) ([]model.TorrentFile, error) {
+	if obj.Files != nil {
+		return obj.Files, nil
+	}
+
+	if !obj.HasFilesInfo() {
+		return nil, nil
+	}
+
+	result, err := gqlmodel.TorrentQuery{
+		Search: r.Search,
+	}.Files(ctx, gqlmodel.TorrentFilesQueryInput{
+		InfoHashes: []protocol.ID{obj.InfoHash},
+		Limit:      model.NewNullUint(torrentFilesResolverLimit(*obj)),
+		OrderBy: []gen.TorrentFilesOrderByInput{
+			{
+				Field: gen.TorrentFilesOrderByFieldIndex,
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Items, nil
 }
 
 // Sources is the resolver for the sources field.
@@ -35,3 +65,15 @@ func (r *Resolver) Torrent() gql.TorrentResolver { return &torrentResolver{r} }
 
 type contentResolver struct{ *Resolver }
 type torrentResolver struct{ *Resolver }
+
+func torrentFilesResolverLimit(t model.Torrent) uint {
+	if t.FilesCount.Valid {
+		return t.FilesCount.Uint
+	}
+
+	if t.FilesStatus == model.FilesStatusSingle {
+		return 1
+	}
+
+	return uint(^uint(0) >> 1)
+}

--- a/internal/gql/resolvers/models_resolvers_test.go
+++ b/internal/gql/resolvers/models_resolvers_test.go
@@ -1,0 +1,121 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bitmagnet-io/bitmagnet/internal/database/query"
+	"github.com/bitmagnet-io/bitmagnet/internal/database/search"
+	"github.com/bitmagnet-io/bitmagnet/internal/model"
+	"github.com/bitmagnet-io/bitmagnet/internal/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSearch struct {
+	torrentFilesCalls  int
+	torrentFilesResult search.TorrentFilesResult
+	torrentFilesErr    error
+}
+
+func (f *fakeSearch) Content(_ context.Context, _ ...query.Option) (search.ContentResult, error) {
+	return search.ContentResult{}, nil
+}
+
+func (f *fakeSearch) QueueJobs(_ context.Context, _ ...query.Option) (search.QueueJobResult, error) {
+	return search.QueueJobResult{}, nil
+}
+
+func (f *fakeSearch) Torrents(_ context.Context, _ ...query.Option) (search.TorrentsResult, error) {
+	return search.TorrentsResult{}, nil
+}
+
+func (f *fakeSearch) TorrentsWithMissingInfoHashes(
+	_ context.Context,
+	_ []protocol.ID,
+	_ ...query.Option,
+) (search.TorrentsWithMissingInfoHashesResult, error) {
+	return search.TorrentsWithMissingInfoHashesResult{}, nil
+}
+
+func (f *fakeSearch) TorrentSuggestTags(
+	_ context.Context,
+	_ search.SuggestTagsQuery,
+	_ ...query.Option,
+) (search.TorrentSuggestTagsResult, error) {
+	return search.TorrentSuggestTagsResult{}, nil
+}
+
+func (f *fakeSearch) TorrentContent(_ context.Context, _ ...query.Option) (search.TorrentContentResult, error) {
+	return search.TorrentContentResult{}, nil
+}
+
+func (f *fakeSearch) TorrentFiles(_ context.Context, _ ...query.Option) (search.TorrentFilesResult, error) {
+	f.torrentFilesCalls++
+	return f.torrentFilesResult, f.torrentFilesErr
+}
+
+func TestTorrentResolverFilesReturnsPreloadedFiles(t *testing.T) {
+	fake := &fakeSearch{}
+	resolver := torrentResolver{&Resolver{Search: fake}}
+	expected := []model.TorrentFile{
+		{
+			InfoHash: protocol.MustParseID("1111111111111111111111111111111111111111"),
+			Index:    0,
+			Path:     "movie.mkv",
+			Size:     1024,
+		},
+	}
+
+	got, err := resolver.Files(context.Background(), &model.Torrent{Files: expected})
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+	require.Zero(t, fake.torrentFilesCalls)
+}
+
+func TestTorrentResolverFilesReturnsNilWithoutFilesInfo(t *testing.T) {
+	fake := &fakeSearch{}
+	resolver := torrentResolver{&Resolver{Search: fake}}
+
+	got, err := resolver.Files(context.Background(), &model.Torrent{})
+	require.NoError(t, err)
+	require.Nil(t, got)
+	require.Zero(t, fake.torrentFilesCalls)
+}
+
+func TestTorrentResolverFilesLoadsMissingFilesFromSearch(t *testing.T) {
+	expected := []model.TorrentFile{
+		{
+			InfoHash: protocol.MustParseID("2222222222222222222222222222222222222222"),
+			Index:    0,
+			Path:     "episode-01.mkv",
+			Size:     2048,
+		},
+		{
+			InfoHash: protocol.MustParseID("2222222222222222222222222222222222222222"),
+			Index:    1,
+			Path:     "episode-02.mkv",
+			Size:     4096,
+		},
+	}
+	fake := &fakeSearch{
+		torrentFilesResult: search.TorrentFilesResult{
+			Items: expected,
+		},
+	}
+	resolver := torrentResolver{&Resolver{Search: fake}}
+
+	got, err := resolver.Files(context.Background(), &model.Torrent{
+		InfoHash:    expected[0].InfoHash,
+		FilesStatus: model.FilesStatusMulti,
+		FilesCount:  model.NewNullUint(uint(len(expected))),
+	})
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+	require.Equal(t, 1, fake.torrentFilesCalls)
+}
+
+func TestTorrentFilesResolverLimitUsesSingleFileFallback(t *testing.T) {
+	require.Equal(t, uint(1), torrentFilesResolverLimit(model.Torrent{
+		FilesStatus: model.FilesStatusSingle,
+	}))
+}


### PR DESCRIPTION
## Summary
- make `Torrent.files` a gqlgen field resolver so it can lazy-load files when the parent torrent was not hydrated with them
- return preloaded files unchanged and preserve `nil` when Bitmagnet has no file metadata for the torrent
- add resolver tests covering preloaded, missing-info, and lazy-load paths

## Rationale
Issue #425 reports that `torrentContent.search()` can return `hasFilesInfo: true` while nested `torrent.files` resolves to `null`.

That happens because `torrentContent.search()` hydrates the parent torrent record but not its associated files, and `Torrent.files` currently reads `obj.Files` directly. This change keeps the search query itself lean and only loads files when the GraphQL selection set actually asks for them.

When `files` is requested, the new resolver fetches the full file list ordered by index using the existing torrent-files search path.

## Testing
- `go test ./internal/gql/resolvers/...`
- `go test ./internal/gql/...`
- `go test ./...`

Closes bitmagnet-io/bitmagnet#425