### PR TITLE
Add web UI permalink link tags to Torznab results

### DIFF
--- a/internal/torznab/httpserver/handler.go
+++ b/internal/torznab/httpserver/handler.go
@@ -110,6 +110,7 @@ func (h handler) handleSearch(ctx *gin.Context, profile torznab.Profile, tp stri
 		return
 	}
 
+	addPermalinks(ctx, &result)
 	h.writeXML(ctx, result)
 }
 
@@ -177,4 +178,55 @@ func (h handler) getProfile(c *gin.Context) (torznab.Profile, error) {
 
 		return profile, nil
 	}
+}
+
+func addPermalinks(ctx *gin.Context, result *torznab.SearchResult) {
+	baseURL := requestBaseURL(ctx)
+	if baseURL == "" {
+		return
+	}
+
+	for i := range result.Channel.Items {
+		if result.Channel.Items[i].GUID == "" {
+			continue
+		}
+
+		permalink := baseURL + "/webui/torrents/permalink/" + result.Channel.Items[i].GUID
+		result.Channel.Items[i].Link = permalink
+
+		if result.Channel.Items[i].Comments == "" {
+			result.Channel.Items[i].Comments = permalink
+		}
+	}
+}
+
+func requestBaseURL(ctx *gin.Context) string {
+	host := forwardedHeaderValue(ctx, "X-Forwarded-Host")
+	if host == "" {
+		host = ctx.Request.Host
+	}
+	if host == "" {
+		return ""
+	}
+
+	scheme := forwardedHeaderValue(ctx, "X-Forwarded-Proto")
+	if scheme == "" {
+		if ctx.Request.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	prefix := strings.TrimSuffix(forwardedHeaderValue(ctx, "X-Forwarded-Prefix"), "/")
+	if prefix != "" && !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+
+	return scheme + "://" + host + prefix
+}
+
+func forwardedHeaderValue(ctx *gin.Context, key string) string {
+	value := strings.TrimSpace(strings.Split(ctx.Request.Header.Get(key), ",")[0])
+	return strings.TrimSpace(value)
 }

--- a/internal/torznab/httpserver/handler_test.go
+++ b/internal/torznab/httpserver/handler_test.go
@@ -207,3 +207,106 @@ func TestSearch(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchAddsPermalinkLinkAndComments(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	result := torznab.SearchResult{
+		Channel: torznab.SearchResultChannel{
+			Items: []torznab.SearchResultItem{
+				{
+					Title: "test torrent",
+					GUID:  "1111111111111111111111111111111111111111",
+					Size:  1234,
+					Enclosure: torznab.SearchResultItemEnclosure{
+						URL:    "magnet:?xt=urn:btih:1111111111111111111111111111111111111111",
+						Length: "1234",
+						Type:   "application/x-bittorrent;x-scheme-handler/magnet",
+					},
+				},
+			},
+		},
+	}
+
+	h.clientMock.EXPECT().Search(
+		mock.IsType(&gin.Context{}),
+		torznab.SearchRequest{
+			Profile: torznab.ProfileDefault,
+			Type:    torznab.FunctionSearch,
+		},
+	).Return(result, nil).Times(1)
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"http://example.com/torznab/?t=search",
+		nil,
+	)
+	require.NoError(t, err)
+
+	h.engine.ServeHTTP(h.responseRecorder, req)
+
+	assert.Equal(t, http.StatusOK, h.responseRecorder.Code)
+	assert.Contains(
+		t,
+		h.responseRecorder.Body.String(),
+		"<link>http://example.com/webui/torrents/permalink/1111111111111111111111111111111111111111</link>",
+	)
+	assert.Contains(
+		t,
+		h.responseRecorder.Body.String(),
+		"<comments>http://example.com/webui/torrents/permalink/1111111111111111111111111111111111111111</comments>",
+	)
+}
+
+func TestSearchUsesForwardedHeadersForPermalinkBaseURL(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHarness(t)
+	result := torznab.SearchResult{
+		Channel: torznab.SearchResultChannel{
+			Items: []torznab.SearchResultItem{
+				{
+					Title: "test torrent",
+					GUID:  "2222222222222222222222222222222222222222",
+					Size:  5678,
+					Enclosure: torznab.SearchResultItemEnclosure{
+						URL:    "magnet:?xt=urn:btih:2222222222222222222222222222222222222222",
+						Length: "5678",
+						Type:   "application/x-bittorrent;x-scheme-handler/magnet",
+					},
+				},
+			},
+		},
+	}
+
+	h.clientMock.EXPECT().Search(
+		mock.IsType(&gin.Context{}),
+		torznab.SearchRequest{
+			Profile: torznab.ProfileDefault,
+			Type:    torznab.FunctionSearch,
+		},
+	).Return(result, nil).Times(1)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/torznab/?t=search", nil)
+	require.NoError(t, err)
+	req.Host = "internal:3333"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "downloads.example.com")
+	req.Header.Set("X-Forwarded-Prefix", "/bitmagnet")
+
+	h.engine.ServeHTTP(h.responseRecorder, req)
+
+	assert.Equal(t, http.StatusOK, h.responseRecorder.Code)
+	assert.Contains(
+		t,
+		h.responseRecorder.Body.String(),
+		"<link>https://downloads.example.com/bitmagnet/webui/torrents/permalink/2222222222222222222222222222222222222222</link>",
+	)
+	assert.Contains(
+		t,
+		h.responseRecorder.Body.String(),
+		"<comments>https://downloads.example.com/bitmagnet/webui/torrents/permalink/2222222222222222222222222222222222222222</comments>",
+	)
+}


### PR DESCRIPTION
## Summary
- populate Torznab item `link` fields with web UI permalinks derived from the request host and forwarded headers
- fill `comments` with the same permalink when it is otherwise empty for better feed compatibility
- add handler tests covering both direct requests and reverse-proxied base URLs

## Rationale
Issue #349 reports missing `link` tags in Torznab results.

In the issue discussion, @mgdigital said the `link` should be a web UI permalink rather than a magnet link, but only when Bitmagnet can determine the correct base URL. This change keeps that logic in the HTTP layer, where the request host and proxy headers are available, and builds permalinks from the incoming request instead of hard-coding any deployment-specific URL.

## Testing
- `go test ./internal/torznab/httpserver/...`
- `go test ./internal/torznab/...`
- `go test ./...`

Closes bitmagnet-io/bitmagnet#349