### PR TITLE
Use named regex capture groups in ParseVideoContent

### DIFF
--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -68,6 +68,43 @@ func TestClassifier(t *testing.T) {
 		},
 		{
 			torrent: model.Torrent{
+				Name:        "[Group] Cool Anime Name S4 - 02 (1080p) [FFAA1234].mkv",
+				FilesStatus: model.FilesStatusSingle,
+				Extension:   model.NewNullString("mkv"),
+				Size:        1000000000,
+			},
+			prepareMocks: func(mocks testClassifierMocks) {
+				mocks.search.On(
+					"ContentBySearch",
+					matchContext,
+					model.ContentTypeTvShow,
+					"Cool Anime Name",
+					mock.Anything,
+				).
+					Return(model.Content{}, classification.ErrUnmatched)
+				mocks.tmdbClient.On(
+					"SearchTv",
+					matchContext,
+					tmdb.SearchTvRequest{
+						Query:        "Cool Anime Name",
+						IncludeAdult: true,
+					},
+				).
+					Return(tmdb.SearchTvResponse{}, nil)
+			},
+			expected: classification.Result{
+				ContentAttributes: classification.ContentAttributes{
+					ContentType: model.NewNullContentType(model.ContentTypeTvShow),
+					BaseTitle:   model.NewNullString("Cool Anime Name"),
+					Episodes: model.Episodes{
+						4: {2: {}},
+					},
+					VideoResolution: model.NewNullVideoResolution(model.VideoResolutionV1080p),
+				},
+			},
+		},
+		{
+			torrent: model.Torrent{
 				Name:        "The Regular Local Movie (2000).mkv",
 				FilesStatus: model.FilesStatusSingle,
 				Extension:   model.NewNullString("mkv"),

--- a/internal/classifier/parsers/video.go
+++ b/internal/classifier/parsers/video.go
@@ -26,7 +26,7 @@ var titleTokens = []dialect.Token{
 			regex.AnyNonWordChar().Repeat().OneOrMore(),
 			rex.Chars.End(),
 		).NonCaptured(),
-	),
+	).WithName("title"),
 }
 
 var titleRegex = rex.New(
@@ -41,7 +41,7 @@ var yearTokens = []dialect.Token{
 			rex.Common.Text("18"), rex.Common.Text("19"), rex.Common.Text("20"),
 		).NonCaptured(),
 		rex.Chars.Digits().Repeat().Exactly(2),
-	),
+	).WithName("year"),
 	rex.Group.Composite(
 		rex.Common.NotClass(rex.Chars.WordCharacter()),
 		rex.Chars.End(),
@@ -67,7 +67,7 @@ var separatorToken = rex.Chars.Runes(" ._")
 
 var titlePartRegex = rex.New(
 	separatorToken.Repeat().ZeroOrOne(),
-	rex.Group.Define(regex.WordToken()),
+	rex.Group.Define(regex.WordToken()).WithName("part"),
 	separatorToken.Repeat().ZeroOrOne(),
 ).MustCompile()
 
@@ -92,7 +92,7 @@ var trimTitleRegex = rex.New(
 			rex.Chars.Any(),
 			regex.WordToken(),
 		).Repeat().ZeroOrMore(),
-	),
+	).WithName("trimmed"),
 	regex.AnyNonWordChar().Repeat().ZeroOrMore(),
 	rex.Chars.End(),
 ).MustCompile()
@@ -104,17 +104,17 @@ func cleanTitle(title string) string {
 			return ""
 		}
 
-		return partMatch[1] + " "
+		return partMatch[titlePartRegex.SubexpIndex("part")] + " "
 	})
-	title = trimTitleRegex.ReplaceAllString(title, "$1")
+	title = trimTitleRegex.ReplaceAllString(title, "${trimmed}")
 
 	return title
 }
 
 func parseTitleYear(input string) (string, model.Year, string, error) {
 	if match := titleYearRegex.FindStringSubmatch(input); match != nil {
-		yearMatch, _ := strconv.ParseUint(match[2], 10, 16)
-		title := cleanTitle(match[1])
+		yearMatch, _ := strconv.ParseUint(match[titleYearRegex.SubexpIndex("year")], 10, 16)
+		title := cleanTitle(match[titleYearRegex.SubexpIndex("title")])
 
 		if title != "" {
 			return title, model.Year(yearMatch), input[len(match[0]):], nil
@@ -126,7 +126,7 @@ func parseTitleYear(input string) (string, model.Year, string, error) {
 
 func parseTitle(input string) (title string, rest string, err error) {
 	if match := titleRegex.FindStringSubmatch(input); match != nil {
-		title = cleanTitle(match[1])
+		title = cleanTitle(match[titleRegex.SubexpIndex("title")])
 		if title != "" {
 			return title, input[len(match[0]):], nil
 		}
@@ -137,7 +137,7 @@ func parseTitle(input string) (title string, rest string, err error) {
 
 func parseTitleYearEpisodes(input string) (string, model.Year, model.Episodes, string, error) {
 	if match := titleEpisodesRegex.FindStringSubmatch(input); match != nil {
-		title := match[1]
+		title := match[titleEpisodesRegex.SubexpIndex("title")]
 		year := model.Year(0)
 
 		if t, y, _, err := parseTitleYear(title); err == nil {
@@ -147,7 +147,7 @@ func parseTitleYearEpisodes(input string) (string, model.Year, model.Episodes, s
 			title = cleanTitle(title)
 		}
 
-		episodes := model.EpisodesMatchToEpisodes(match[2:])
+		episodes := model.EpisodesMatchToEpisodes(titleEpisodesRegex, match)
 
 		return title, year, episodes, input[len(match[0]):], nil
 	}

--- a/internal/model/episodes_parser.go
+++ b/internal/model/episodes_parser.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -9,9 +10,9 @@ import (
 	"github.com/hedhyw/rex/pkg/rex"
 )
 
-func rangeToken(runes string) dialect.Token {
+func rangeToken(runes string, startName, dashEndName, commaEndName string) dialect.Token {
 	return rex.Group.Define(
-		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)),
+		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName(startName),
 		rex.Group.Composite(
 			rex.Group.Define(
 				rex.Chars.Whitespace().Repeat().ZeroOrOne(),
@@ -21,7 +22,7 @@ func rangeToken(runes string) dialect.Token {
 					rex.Chars.Runes(runes).Repeat().ZeroOrOne(),
 					rex.Chars.Whitespace().Repeat().ZeroOrOne(),
 				).Repeat().ZeroOrOne(),
-				rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)),
+				rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName(dashEndName),
 			).NonCaptured(),
 			rex.Group.Define(
 				rex.Chars.Whitespace().Repeat().ZeroOrOne(),
@@ -31,7 +32,7 @@ func rangeToken(runes string) dialect.Token {
 					rex.Chars.Runes(runes).Repeat().ZeroOrOne(),
 					rex.Chars.Whitespace().Repeat().ZeroOrOne(),
 				).Repeat().ZeroOrOne(),
-				rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)),
+				rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName(commaEndName),
 				rex.Chars.Whitespace().Repeat().ZeroOrOne(),
 			).NonCaptured().Repeat().OneOrMore(),
 		).NonCaptured().Repeat().ZeroOrOne(),
@@ -43,7 +44,7 @@ var seasonToken = rex.Group.Define(
 		keywords.MustNewRexTokensFromKeywords("season", "s")...,
 	).NonCaptured(),
 	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
-	rangeToken("sS"),
+	rangeToken("sS", "seasonStart", "seasonDashEnd", "seasonCommaEnd"),
 	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
 ).NonCaptured()
 
@@ -52,25 +53,35 @@ var episodeToken = rex.Group.Define(
 		keywords.MustNewRexTokensFromKeywords("episode", "ep", "e")...,
 	).NonCaptured(),
 	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
-	rangeToken("eE"),
+	rangeToken("eE", "episodeStart", "episodeDashEnd", "episodeCommaEnd"),
+).NonCaptured()
+
+var episodeDashToken = rex.Group.Define(
+	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
+	rex.Chars.Single('-'),
+	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
+	rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName("episodeStart"),
 ).NonCaptured()
 
 var episodesRegularTokens = rex.Group.Define(
 	seasonToken,
-	episodeToken.Repeat().ZeroOrOne(),
+	rex.Group.Composite(
+		episodeToken,
+		episodeDashToken,
+	).NonCaptured().Repeat().ZeroOrOne(),
 ).NonCaptured()
 
 var episodesXFormatTokens = rex.Group.Define(
 	rex.Group.Define(
-		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)),
+		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName("xSeason"),
 		rex.Chars.Runes("xX"),
-		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)),
+		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName("xEpisodeStart"),
 	).NonCaptured(),
 	rex.Group.Define(
 		rex.Chars.Whitespace().Repeat().ZeroOrOne(),
 		rex.Chars.Single('-'),
 		rex.Chars.Whitespace().Repeat().ZeroOrOne(),
-		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)),
+		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName("xEpisodeEnd"),
 	).NonCaptured().Repeat().ZeroOrOne(),
 ).NonCaptured()
 
@@ -85,30 +96,59 @@ var episodesRegex = rex.New(
 	rex.Chars.End(),
 ).MustCompile()
 
-func EpisodesMatchToEpisodes(match []string) Episodes {
-	if len(match) < 12 {
+func namedMatch(re *regexp.Regexp, match []string, name string) string {
+	for i, n := range re.SubexpNames() {
+		if n == name && i < len(match) {
+			return match[i]
+		}
+	}
+	return ""
+}
+
+// EpisodesMatchToEpisodes converts a regex submatch to Episodes using named groups.
+// The re parameter should be a regex compiled from EpisodesToken.
+func EpisodesMatchToEpisodes(re *regexp.Regexp, match []string) Episodes {
+	if match == nil {
 		return nil
+	}
+
+	nm := func(name string) string {
+		return namedMatch(re, match, name)
 	}
 
 	episodes := Episodes{}
 
-	if match[1] != "" {
+	if nm("seasonStart") != "" {
 		// regular format
-		seasonStart, _ := strconv.ParseInt(match[2], 10, 16)
+		seasonStart, _ := strconv.ParseInt(nm("seasonStart"), 10, 16)
 
-		if match[5] == "" {
+		if nm("episodeStart") == "" {
 			// no episodes
 			switch {
-			case match[3] != "":
+			case nm("seasonDashEnd") != "":
 				// a season range
-				seasonEnd, _ := strconv.ParseInt(match[3], 10, 16)
+				seasonEnd, _ := strconv.ParseInt(nm("seasonDashEnd"), 10, 16)
 				for i := seasonStart; i <= seasonEnd; i++ {
 					episodes = episodes.AddSeason(int(i))
 				}
-			case match[4] != "":
-				// a list of seasons
-				includedSeasons := strings.Split(match[1], ",")
+			case nm("seasonCommaEnd") != "":
+				// a list of seasons - find the parent range group containing commas
+				var seasonRange string
+				for i, n := range re.SubexpNames() {
+					if n == "seasonStart" && i < len(match) {
+						for j := i - 1; j >= 0; j-- {
+							if match[j] != "" && strings.Contains(match[j], ",") {
+								seasonRange = match[j]
+								break
+							}
+						}
+						break
+					}
+				}
+				includedSeasons := strings.Split(seasonRange, ",")
 				for _, season := range includedSeasons {
+					season = strings.TrimSpace(season)
+					season = strings.TrimLeft(season, "sS ")
 					seasonIndex, _ := strconv.ParseInt(season, 10, 16)
 					episodes = episodes.AddSeason(int(seasonIndex))
 				}
@@ -118,19 +158,33 @@ func EpisodesMatchToEpisodes(match []string) Episodes {
 			}
 		} else {
 			// episodes
-			episodeStart, _ := strconv.ParseInt(match[6], 10, 16)
+			episodeStart, _ := strconv.ParseInt(nm("episodeStart"), 10, 16)
 
 			switch {
-			case match[7] != "":
+			case nm("episodeDashEnd") != "":
 				// an episode range
-				episodeEnd, _ := strconv.ParseInt(match[7], 10, 16)
+				episodeEnd, _ := strconv.ParseInt(nm("episodeDashEnd"), 10, 16)
 				for i := episodeStart; i <= episodeEnd; i++ {
 					episodes = episodes.AddEpisode(int(seasonStart), int(i))
 				}
-			case match[8] != "":
-				// a list of episodes
-				includedEpisodes := strings.Split(match[5], ",")
+			case nm("episodeCommaEnd") != "":
+				// a list of episodes - find the parent range group containing commas
+				var episodeRange string
+				for i, n := range re.SubexpNames() {
+					if n == "episodeStart" && i < len(match) {
+						for j := i - 1; j >= 0; j-- {
+							if match[j] != "" && strings.Contains(match[j], ",") {
+								episodeRange = match[j]
+								break
+							}
+						}
+						break
+					}
+				}
+				includedEpisodes := strings.Split(episodeRange, ",")
 				for _, episode := range includedEpisodes {
+					episode = strings.TrimSpace(episode)
+					episode = strings.TrimLeft(episode, "eE ")
 					episodeIndex, _ := strconv.ParseInt(episode, 10, 16)
 					episodes = episodes.AddEpisode(int(seasonStart), int(episodeIndex))
 				}
@@ -141,12 +195,12 @@ func EpisodesMatchToEpisodes(match []string) Episodes {
 		}
 	} else {
 		// x format
-		season, _ := strconv.ParseInt(match[9], 10, 16)
-		episodeStart, _ := strconv.ParseInt(match[10], 10, 16)
+		season, _ := strconv.ParseInt(nm("xSeason"), 10, 16)
+		episodeStart, _ := strconv.ParseInt(nm("xEpisodeStart"), 10, 16)
 		episodeEnd := episodeStart
 
-		if match[11] != "" {
-			episodeEnd, _ = strconv.ParseInt(match[11], 10, 16)
+		if nm("xEpisodeEnd") != "" {
+			episodeEnd, _ = strconv.ParseInt(nm("xEpisodeEnd"), 10, 16)
 		}
 
 		for i := episodeStart; i <= episodeEnd; i++ {
@@ -158,5 +212,5 @@ func EpisodesMatchToEpisodes(match []string) Episodes {
 }
 
 func ParseEpisodes(input string) Episodes {
-	return EpisodesMatchToEpisodes(episodesRegex.FindStringSubmatch(input))
+	return EpisodesMatchToEpisodes(episodesRegex, episodesRegex.FindStringSubmatch(input))
 }

--- a/internal/model/episodes_parser.go
+++ b/internal/model/episodes_parser.go
@@ -10,7 +10,19 @@ import (
 	"github.com/hedhyw/rex/pkg/rex"
 )
 
-func rangeToken(runes string, startName, dashEndName, commaEndName string) dialect.Token {
+func rangeToken(runes string, requirePrefix bool, startName, dashEndName, commaEndName string) dialect.Token {
+	var prefixToken dialect.Token
+	if requirePrefix {
+		prefixToken = rex.Group.NonCaptured(
+			rex.Chars.Runes(runes),
+			rex.Chars.Whitespace().Repeat().ZeroOrOne(),
+		)
+	} else {
+		prefixToken = rex.Group.NonCaptured(
+			rex.Chars.Runes(runes).Repeat().ZeroOrOne(),
+			rex.Chars.Whitespace().Repeat().ZeroOrOne(),
+		).Repeat().ZeroOrOne()
+	}
 	return rex.Group.Define(
 		rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName(startName),
 		rex.Group.Composite(
@@ -18,10 +30,7 @@ func rangeToken(runes string, startName, dashEndName, commaEndName string) diale
 				rex.Chars.Whitespace().Repeat().ZeroOrOne(),
 				rex.Chars.Single('-'),
 				rex.Chars.Whitespace().Repeat().ZeroOrOne(),
-				rex.Group.NonCaptured(
-					rex.Chars.Runes(runes).Repeat().ZeroOrOne(),
-					rex.Chars.Whitespace().Repeat().ZeroOrOne(),
-				).Repeat().ZeroOrOne(),
+				prefixToken,
 				rex.Group.Define(rex.Chars.Digits().Repeat().Between(1, 2)).WithName(dashEndName),
 			).NonCaptured(),
 			rex.Group.Define(
@@ -44,7 +53,7 @@ var seasonToken = rex.Group.Define(
 		keywords.MustNewRexTokensFromKeywords("season", "s")...,
 	).NonCaptured(),
 	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
-	rangeToken("sS", "seasonStart", "seasonDashEnd", "seasonCommaEnd"),
+	rangeToken("sS", true, "seasonStart", "seasonDashEnd", "seasonCommaEnd"),
 	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
 ).NonCaptured()
 
@@ -53,7 +62,7 @@ var episodeToken = rex.Group.Define(
 		keywords.MustNewRexTokensFromKeywords("episode", "ep", "e")...,
 	).NonCaptured(),
 	rex.Chars.Whitespace().Repeat().ZeroOrOne(),
-	rangeToken("eE", "episodeStart", "episodeDashEnd", "episodeCommaEnd"),
+	rangeToken("eE", false, "episodeStart", "episodeDashEnd", "episodeCommaEnd"),
 ).NonCaptured()
 
 var episodeDashToken = rex.Group.Define(
@@ -97,12 +106,14 @@ var episodesRegex = rex.New(
 ).MustCompile()
 
 func namedMatch(re *regexp.Regexp, match []string, name string) string {
+	result := ""
 	for i, n := range re.SubexpNames() {
-		if n == name && i < len(match) {
-			return match[i]
+		if n == name && i < len(match) && match[i] != "" {
+			result = match[i]
+			break
 		}
 	}
-	return ""
+	return result
 }
 
 // EpisodesMatchToEpisodes converts a regex submatch to Episodes using named groups.


### PR DESCRIPTION
This PR adds named regex capture groups. That allows using less magic numbers when reading out the parsed info from torrent names. 

I have also added support for an additional name format with test.

This PR has been running quite well for last week for me.