### PR TITLE
fix(dht): unmap IPv4-in-IPv6 addresses to prevent EAFNOSUPPORT

### DIFF
--- a/internal/protocol/dht/server/socket_unix.go
+++ b/internal/protocol/dht/server/socket_unix.go
@@ -62,16 +62,22 @@ func (s *socket) Receive(data []byte) (int, netip.AddrPort, error) {
 }
 
 func addrPortToSockaddr(addr netip.AddrPort) (unix.Sockaddr, error) {
-	if addr.Addr().Is4() {
+	// Unmap IPv4-in-IPv6 addresses (e.g. ::ffff:1.2.3.4 → 1.2.3.4).
+	// Go's net.ResolveUDPAddr can return mapped-v6 on dual-stack systems,
+	// which would fail with EAFNOSUPPORT on this AF_INET socket.
+	// See https://github.com/bitmagnet-io/bitmagnet/issues/437
+	ip := addr.Addr().Unmap()
+
+	if ip.Is4() {
 		return &unix.SockaddrInet4{
-			Addr: addr.Addr().As4(),
+			Addr: ip.As4(),
 			Port: int(addr.Port()),
 		}, nil
 	}
 
-	if addr.Addr().Is6() {
+	if ip.Is6() {
 		return &unix.SockaddrInet6{
-			Addr: addr.Addr().As16(),
+			Addr: ip.As16(),
 			Port: int(addr.Port()),
 		}, nil
 	}

--- a/internal/protocol/dht/server/socket_unix_test.go
+++ b/internal/protocol/dht/server/socket_unix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package server
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestAddrPortToSockaddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr netip.AddrPort
+		want any
+	}{
+		{
+			name: "IPv4-mapped IPv6 is treated as IPv4",
+			// ::ffff:1.2.3.4 — what Go's resolver can return on dual-stack
+			// systems (https://github.com/bitmagnet-io/bitmagnet/issues/437).
+			addr: netip.AddrPortFrom(netip.MustParseAddr("::ffff:1.2.3.4"), 6881),
+			want: (*unix.SockaddrInet4)(nil),
+		},
+		{
+			name: "pure IPv4",
+			addr: netip.AddrPortFrom(netip.MustParseAddr("1.2.3.4"), 6881),
+			want: (*unix.SockaddrInet4)(nil),
+		},
+		{
+			name: "pure IPv6",
+			addr: netip.AddrPortFrom(netip.MustParseAddr("2001:db8::1"), 6881),
+			want: (*unix.SockaddrInet6)(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := addrPortToSockaddr(tt.addr)
+			assert.NoError(t, err)
+			assert.IsType(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

On dual-stack systems, Go's `net.ResolveUDPAddr` can return IPv4-mapped IPv6 addresses (e.g. `::ffff:1.2.3.4`) for plain IPv4 hostnames. The DHT server uses an `AF_INET` (IPv4-only) socket, so passing an IPv6 sockaddr to `Sendto` fails with `EAFNOSUPPORT` ("address family not supported by protocol"), preventing the DHT crawler from functioning.

Reported in #437 — the crawler stays in `down` status, zero DHT traffic leaves the host.

Confirmed on Synology DSM (dual-stack, link-local IPv6 enabled). Other users on dual-stack Linux systems hit the same issue (see comments on #437 — even explicit `ip:port` inputs fail).

## Fix

Call `Addr.Unmap()` in `addrPortToSockaddr` before the `Is4()` / `Is6()` check. This normalizes `::ffff:1.2.3.4` back to `1.2.3.4`, producing the correct `SockaddrInet4` for the `AF_INET` socket.

```diff
 func addrPortToSockaddr(addr netip.AddrPort) (unix.Sockaddr, error) {
+	// Unmap IPv4-in-IPv6 addresses (e.g. ::ffff:1.2.3.4 → 1.2.3.4).
+	// Go's net.ResolveUDPAddr can return mapped-v6 on dual-stack systems,
+	// which would fail with EAFNOSUPPORT on this AF_INET socket.
+	ip := addr.Addr().Unmap()
+
 	if ip.Is4() {
 		return &unix.SockaddrInet4{
 			Addr: ip.As4(),
```

## Verification

Deployed a patched image on a Synology DS220+ (dual-stack, where the bug reproduced). Before the patch, `bitmagnet_dht_server_query_error_total{query="ping"}` incremented by ~6/min (once per bootstrap node) and `dht_ktable_nodes_count` stayed at 0. After the patch, within 2 minutes:

- `dht: up` in `/status` (previously `down | no response within 30 seconds`)
- `dht_ktable_nodes_count`: **145** (was 0)
- `dht_ktable_hashes_count`: 200 infohashes discovered
- `dht_crawler_persisted_total{entity="Torrent"}`: 14 new torrents persisted

## Tests

Added a table-driven unit test covering all three address forms:

- IPv4-mapped IPv6 (`::ffff:1.2.3.4`) → `SockaddrInet4` (the regression case)
- Pure IPv4 → `SockaddrInet4` (unchanged behavior)
- Pure IPv6 (`2001:db8::1`) → `SockaddrInet6` (unchanged behavior)

Fixes #437
